### PR TITLE
USGS Fix, NMBGMR Fix, & Other Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,12 @@ The USGS now uses [API keys](https://api.waterdata.usgs.gov/signup/) to increase
 die weave waterlevels --output-type timeseries_unified --usgs-api-key FAKE_API_KEY
 ```
 
+or
+
+```
+die sites --usgs-api-key FAKE_API_KEY
+```
+
 ### Geographic Filters [In Development]
 
 The following flags can be used to geographically filter data:

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Data comes from the following sources. We are continuously adding new sources as
   - Available data: `water levels`
 - [USGS (NWIS)](https://api.waterdata.usgs.gov/docs/)
   - Available data: `water levels`
-  - **IMPORTANT** The USGS now uses API keys. To prevent yourself from hitting the rate limit please acquire an API key, save it, and provide it via the `--usgs-api-key` flag when gathering water level data from the USGS.
+  - **IMPORTANT:** The USGS now uses API keys. To prevent yourself from hitting the rate limit please acquire an API key, save it, and provide it via the `--usgs-api-key` flag when gathering water level data from the USGS.
 - [Water Quality Portal (WQP)](https://www.waterqualitydata.us/)
   - Available data: `water levels`, `water quality`
 

--- a/README.md
+++ b/README.md
@@ -38,8 +38,9 @@ Data comes from the following sources. We are continuously adding new sources as
   - Available data: `water levels`
 - [Pecos Valley Artesian Conservancy District (PVACD)](https://st2.newmexicowaterdata.org/FROST-Server/v1.1/Locations?$filter=properties/agency%20eq%20%27PVACD%27)
   - Available data: `water levels`
-- [USGS (NWIS)](https://waterdata.usgs.gov/nwis)
+- [USGS (NWIS)](https://api.waterdata.usgs.gov/docs/)
   - Available data: `water levels`
+  - **IMPORTANT** The USGS now uses API keys. To prevent yourself from hitting the rate limit please acquire an API key and provide it via the `--usgs-api-key` flag when gathering water level data from the USGS.
 - [Water Quality Portal (WQP)](https://www.waterqualitydata.us/)
   - Available data: `water levels`, `water quality`
 
@@ -188,6 +189,14 @@ The Data Integration Engine enables the user to obtain groundwater level and gro
 - `--no-nwis` to exclude USGS NWIS data
 - `--no-pvacd` to exclude Pecos Valley Artesian Convservancy District (PVACD) data
 - `--no-wqp` to exclude Water Quality Portal (WQP) data
+
+### USGS API Keys
+
+The USGS now uses [API keys](https://api.waterdata.usgs.gov/signup/) to increase the query rate limit to their APIs. If you intend to include USGS water level data in your output please acquire an API key, save it somewhere, and provide it via the `--usgs-api-key` flag. For example:
+
+```
+die weave waterlevels --output-type timeseries_unified --usgs-api-key FAKE_API_KEY
+```
 
 ### Geographic Filters [In Development]
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Data comes from the following sources. We are continuously adding new sources as
   - Available data: `water levels`
 - [USGS (NWIS)](https://api.waterdata.usgs.gov/docs/)
   - Available data: `water levels`
-  - **IMPORTANT** The USGS now uses API keys. To prevent yourself from hitting the rate limit please acquire an API key and provide it via the `--usgs-api-key` flag when gathering water level data from the USGS.
+  - **IMPORTANT** The USGS now uses API keys. To prevent yourself from hitting the rate limit please acquire an API key, save it, and provide it via the `--usgs-api-key` flag when gathering water level data from the USGS.
 - [Water Quality Portal (WQP)](https://www.waterqualitydata.us/)
   - Available data: `water levels`, `water quality`
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Data comes from the following sources. We are continuously adding new sources as
   - Available data: `water levels`
 - [USGS (NWIS)](https://api.waterdata.usgs.gov/docs/)
   - Available data: `water levels`
-  - **IMPORTANT:** The USGS now uses API keys. To prevent yourself from hitting the rate limit please acquire an API key, save it, and provide it via the `--usgs-api-key` flag when gathering water level data from the USGS.
+  - **IMPORTANT:** The USGS now uses API keys. To prevent yourself from hitting the rate limit please [acquire an API key](https://api.waterdata.usgs.gov/signup/), save it, and provide it via the `--usgs-api-key` flag when gathering water level data from the USGS.
 - [Water Quality Portal (WQP)](https://www.waterqualitydata.us/)
   - Available data: `water levels`, `water quality`
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Data comes from the following sources. We are continuously adding new sources as
   - Available data: `water levels`
 - [USGS (NWIS)](https://api.waterdata.usgs.gov/docs/)
   - Available data: `water levels`
-  - **IMPORTANT:** The USGS now uses API keys. To prevent yourself from hitting the rate limit please [acquire an API key](https://api.waterdata.usgs.gov/signup/), save it, and provide it via the `--usgs-api-key` flag when gathering water level data from the USGS.
+  - **IMPORTANT:** The USGS now uses API keys. To prevent yourself from hitting the rate limit please [acquire an API key](https://api.waterdata.usgs.gov/signup/), save it, and provide it via the `--usgs-api-key` flag when gathering water level or site data from the USGS.
 - [Water Quality Portal (WQP)](https://www.waterqualitydata.us/)
   - Available data: `water levels`, `water quality`
 

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ The Data Integration Engine enables the user to obtain groundwater level and gro
 
 ### USGS API Keys
 
-The USGS now uses [API keys](https://api.waterdata.usgs.gov/signup/) to increase the query rate limit to their APIs. If you intend to include USGS water level data in your output please acquire an API key, save it somewhere, and provide it via the `--usgs-api-key` flag. For example:
+The USGS now uses [API keys](https://api.waterdata.usgs.gov/signup/) to increase the query rate limit for their APIs. If you intend to include USGS water level data in your output please acquire an API key, save it somewhere, and provide it via the `--usgs-api-key` flag. For example:
 
 ```
 die weave waterlevels --output-type timeseries_unified --usgs-api-key FAKE_API_KEY

--- a/backend/config.py
+++ b/backend/config.py
@@ -294,7 +294,6 @@ class Config(Loggable):
                 "pvacd",
             ]
         elif self.parameter in [
-            BICARBONATE,
             CALCIUM,
             CHLORIDE,
             FLUORIDE,

--- a/backend/config.py
+++ b/backend/config.py
@@ -281,6 +281,18 @@ class Config(Loggable):
                 "nwis",
                 "pvacd",
             ]
+        elif self.parameter in [BICARBONATE]:
+            config_agencies = ["nmbgmr_amp", "nmed_dwb", "nmose_isc_seven_rivers", "wqp"]
+            false_agencies = [
+                "bor",
+                "bernco",
+                "cabq",
+                "ebid",
+                "nmose_roswell",
+                "nmose_pod",
+                "nwis",
+                "pvacd",
+            ]
         elif self.parameter in [
             BICARBONATE,
             CALCIUM,

--- a/backend/connectors/bor/source.py
+++ b/backend/connectors/bor/source.py
@@ -57,7 +57,7 @@ class BORSiteSource(BaseSiteSource):
         # locationTypeId 10 is for wells
         url = "https://data.usbr.gov/rise/api/location"
         params = {"stateId": "NM", "locationTypeId": 10}
-        return self._execute_json_request(url, params)
+        return self._execute_json_request(url, params, tag="data")
 
 
 def parse_dt(dt):
@@ -119,13 +119,14 @@ class BORAnalyteSource(BaseAnalyteSource):
         code = get_analyte_search_param(self.config.parameter, BOR_ANALYTE_MAPPING)
 
         catalog_record_data = self._execute_json_request(
-            f"https://data.usbr.gov{site_record.catalogRecords[0]['id']}"
+            f"https://data.usbr.gov{site_record.catalogRecords[0]['id']}",
+            tag="data"
         )
         catalog_items = catalog_record_data["relationships"]["catalogItems"]["data"]
 
         for i, item in enumerate(self._reorder_catalog_items(catalog_items)):
 
-            data = self._execute_json_request(f'https://data.usbr.gov{item["id"]}')
+            data = self._execute_json_request(f'https://data.usbr.gov{item["id"]}', tag="data")
             if not data:
                 continue
 
@@ -142,6 +143,7 @@ class BORAnalyteSource(BaseAnalyteSource):
                 return self._execute_json_request(
                     "https://data.usbr.gov/rise/api/result",
                     params={"itemId": data["attributes"]["_id"]},
+                    tag="data"
                 )
 
 

--- a/backend/connectors/bor/source.py
+++ b/backend/connectors/bor/source.py
@@ -48,8 +48,8 @@ class BORSiteSource(BaseSiteSource):
 
     def health(self):
         try:
-            self.get_records()
-            return True
+            resp = self.get_records()
+            return bool(resp)
         except Exception:
             return False
 

--- a/backend/connectors/isc_seven_rivers/source.py
+++ b/backend/connectors/isc_seven_rivers/source.py
@@ -85,6 +85,7 @@ class ISCSevenRiversSiteSource(BaseSiteSource):
     def get_records(self):
         return self._execute_json_request(
             _make_url("getMonitoringPoints.ashx"),
+            tag="data",
         )
 
 
@@ -100,7 +101,7 @@ class ISCSevenRiversAnalyteSource(BaseAnalyteSource):
         """ """
         if self._analyte_ids is None:
 
-            resp = self._execute_json_request(_make_url("getAnalytes.ashx"))
+            resp = self._execute_json_request(_make_url("getAnalytes.ashx"), tag="data")
             if resp:
                 self._analyte_ids = {r["name"]: r["id"] for r in resp}
 
@@ -164,7 +165,7 @@ class ISCSevenRiversAnalyteSource(BaseAnalyteSource):
                 self._source_parameter_name = analyte_id_and_name["name"]
 
             return self._execute_json_request(
-                _make_url("getReadings.ashx"), params=params
+                _make_url("getReadings.ashx"), params=params, tag="data"
             )
 
 
@@ -184,6 +185,7 @@ class ISCSevenRiversWaterLevelSource(BaseWaterLevelSource):
         return self._execute_json_request(
             _make_url("getWaterLevels.ashx"),
             params=params,
+            tag="data",
         )
 
     def _clean_records(self, records):

--- a/backend/connectors/isc_seven_rivers/source.py
+++ b/backend/connectors/isc_seven_rivers/source.py
@@ -76,8 +76,8 @@ class ISCSevenRiversSiteSource(BaseSiteSource):
 
     def health(self):
         try:
-            self.get_records()
-            return True
+            resp = self.get_records()
+            return bool(resp)
         except Exception as e:
             print("Failed to get records", e)
             return False

--- a/backend/connectors/nmbgmr/source.py
+++ b/backend/connectors/nmbgmr/source.py
@@ -88,19 +88,9 @@ class NMBGMRSiteSource(BaseSiteSource):
             else:
                 params["parameter"] = "Manual groundwater levels"
 
-        # tags="features" because the response object is a GeoJSON
-        request_finished: bool = False
-        while not request_finished:
-            try:
-                sites = self._execute_json_request(
-                    _make_url("locations"), params, tag="features", timeout=TIMEOUT
-                )
-                if sites is None:
-                    self.warn("Retrying...")
-                    continue
-                request_finished = True
-            except Exception as e:
-                self.warn(f"Error retrieving site data: {e}. Retrying...")
+        sites = self._execute_json_request(
+            _make_url("locations"), params, tag="features", timeout=TIMEOUT
+        )
 
         if not config.sites_only:
             for site in sites:
@@ -136,25 +126,16 @@ class NMBGMRAnalyteSource(BaseAnalyteSource):
             self.config.parameter, NMBGMR_ANALYTE_MAPPING
         )
 
-        request_finished: bool = False
+        records = self._execute_json_request(
+            _make_url("waterchemistry"),
+            params={
+                "pointid": ",".join(make_site_list(site_record)),
+                "analyte": analyte,
+            },
+            tag="",
+            timeout=TIMEOUT
+        )
 
-        while not request_finished:
-            try:
-                records = self._execute_json_request(
-                    _make_url("waterchemistry"),
-                    params={
-                        "pointid": ",".join(make_site_list(site_record)),
-                        "analyte": analyte,
-                    },
-                    tag="",
-                    timeout=TIMEOUT
-                )
-                if records is None:
-                    self.warn("Retrying...")
-                    continue
-                request_finished = True
-            except Exception as e:
-                self.warn(f"Error retrieving analyte data: {e}. Retrying...")
         records_sorted_by_pointid = {}
         for pointid in records.keys():
             records_sorted_by_pointid[pointid] = records[pointid][analyte]
@@ -252,16 +233,8 @@ class NMBGMRWaterLevelSource(BaseWaterLevelSource):
         # just use manual waterlevels temporarily
         url = _make_url("waterlevels/manual")
 
-        request_finished: bool = False
-        while not request_finished:
-             try:
-                paginated_records = self._execute_json_request(url, params, tag="", timeout=TIMEOUT)
-                if paginated_records is None:
-                    self.warn("Retrying...")
-                    continue
-                request_finished = True
-             except Exception as e:
-                self.warn(f"Error retrieving water level data: {e}. Retrying...")
+        paginated_records = self._execute_json_request(url, params, tag="", timeout=TIMEOUT)
+
         items = paginated_records["items"]
         page = paginated_records["page"]
         pages = paginated_records["pages"]
@@ -270,17 +243,7 @@ class NMBGMRWaterLevelSource(BaseWaterLevelSource):
             page += 1
             params["page"] = page
 
-            request_finished: bool = False
-            while not request_finished:
-                try:
-                    new_records = self._execute_json_request(url, params, tag="", timeout=TIMEOUT)
-                    # status_code != 200 makes _execute_json_request return None, so check for that and retry if it happens
-                    if new_records is None:
-                        self.warn("Retrying...")
-                        continue
-                    request_finished = True
-                except Exception as e:
-                    self.warn(f"Error retrieving page {page} of water level data: {e}. Retrying...")
+            new_records = self._execute_json_request(url, params, tag="", timeout=TIMEOUT)
             
             items.extend(new_records["items"])
             pages = new_records["pages"]

--- a/backend/connectors/nmbgmr/source.py
+++ b/backend/connectors/nmbgmr/source.py
@@ -95,11 +95,11 @@ class NMBGMRSiteSource(BaseSiteSource):
                     _make_url("locations"), params, tag="features", timeout=TIMEOUT
                 )
                 if sites is None:
-                    self.warning("Retrying...")
+                    self.warn("Retrying...")
                     continue
                 request_finished = True
             except Exception as e:
-                self.warning(f"Error retrieving site data: {e}. Retrying...")
+                self.warn(f"Error retrieving site data: {e}. Retrying...")
 
         if not config.sites_only:
             for site in sites:
@@ -149,11 +149,11 @@ class NMBGMRAnalyteSource(BaseAnalyteSource):
                     timeout=TIMEOUT
                 )
                 if records is None:
-                    self.warning("Retrying...")
+                    self.warn("Retrying...")
                     continue
                 request_finished = True
             except Exception as e:
-                self.warning(f"Error retrieving analyte data: {e}. Retrying...")
+                self.warn(f"Error retrieving analyte data: {e}. Retrying...")
         records_sorted_by_pointid = {}
         for pointid in records.keys():
             records_sorted_by_pointid[pointid] = records[pointid][analyte]
@@ -256,11 +256,11 @@ class NMBGMRWaterLevelSource(BaseWaterLevelSource):
              try:
                 paginated_records = self._execute_json_request(url, params, tag="", timeout=TIMEOUT)
                 if paginated_records is None:
-                    self.warning("Retrying...")
+                    self.warn("Retrying...")
                     continue
                 request_finished = True
              except Exception as e:
-                self.warning(f"Error retrieving water level data: {e}. Retrying...")
+                self.warn(f"Error retrieving water level data: {e}. Retrying...")
         items = paginated_records["items"]
         page = paginated_records["page"]
         pages = paginated_records["pages"]
@@ -275,11 +275,11 @@ class NMBGMRWaterLevelSource(BaseWaterLevelSource):
                     new_records = self._execute_json_request(url, params, tag="", timeout=TIMEOUT)
                     # status_code != 200 makes _execute_json_request return None, so check for that and retry if it happens
                     if new_records is None:
-                        self.warning("Retrying...")
+                        self.warn("Retrying...")
                         continue
                     request_finished = True
                 except Exception as e:
-                    self.warning(f"Error retrieving page {page} of water level data: {e}. Retrying...")
+                    self.warn(f"Error retrieving page {page} of water level data: {e}. Retrying...")
             
             items.extend(new_records["items"])
             pages = new_records["pages"]

--- a/backend/connectors/nmbgmr/source.py
+++ b/backend/connectors/nmbgmr/source.py
@@ -49,7 +49,7 @@ from backend.source import (
 # Don't use timeout=None since that can cause the request to hang indefinitely if there are issues with the API.
 # Instead, catch timeout exceptions and retry the request until it succeeds or a different exception is raised.
 
-TIMEOUT=1800
+TIMEOUT=15*60
 
 def _make_url(endpoint):
     if os.getenv("DEBUG") == "1":

--- a/backend/connectors/nmbgmr/source.py
+++ b/backend/connectors/nmbgmr/source.py
@@ -94,6 +94,9 @@ class NMBGMRSiteSource(BaseSiteSource):
                 sites = self._execute_json_request(
                     _make_url("locations"), params, tag="features", timeout=TIMEOUT
                 )
+                if sites is None:
+                    self.warning("Retrying...")
+                    continue
                 request_finished = True
             except Exception as e:
                 self.warning(f"Error retrieving site data: {e}. Retrying...")
@@ -145,6 +148,9 @@ class NMBGMRAnalyteSource(BaseAnalyteSource):
                     tag="",
                     timeout=TIMEOUT
                 )
+                if records is None:
+                    self.warning("Retrying...")
+                    continue
                 request_finished = True
             except Exception as e:
                 self.warning(f"Error retrieving analyte data: {e}. Retrying...")
@@ -250,6 +256,9 @@ class NMBGMRWaterLevelSource(BaseWaterLevelSource):
         while not request_finished:
              try:
                 paginated_records = self._execute_json_request(url, params, tag="", timeout=TIMEOUT)
+                if paginated_records is None:
+                    self.warning("Retrying...")
+                    continue
                 request_finished = True
              except Exception as e:
                 self.warning(f"Error retrieving water level data: {e}. Retrying...")

--- a/backend/connectors/nmbgmr/source.py
+++ b/backend/connectors/nmbgmr/source.py
@@ -248,7 +248,6 @@ class NMBGMRWaterLevelSource(BaseWaterLevelSource):
         #     url = _make_url("waterlevels/latest")
         # else:
         params = {"pointid": ",".join(make_site_list(site_record))}
-        print(make_site_list(site_record))
         # just use manual waterlevels temporarily
         url = _make_url("waterlevels/manual")
 

--- a/backend/connectors/nmbgmr/source.py
+++ b/backend/connectors/nmbgmr/source.py
@@ -44,10 +44,11 @@ from backend.source import (
     make_site_list,
 )
 
-"""
-Set timeout to 30 minutes for analyte and water level requests since some sites have a large number of records and the NMBGMR API can be slow to respond.
-Don't use timeout=None since that can cause the request to hang indefinitely if there are issues with the API. Instead, catch timeout exceptions and retry the request until it succeeds or a different exception is raised.
-"""
+
+# Set timeout to 30 minutes for analyte and water level requests since some sites have a large number of records and the NMBGMR API can be slow to respond.
+# Don't use timeout=None since that can cause the request to hang indefinitely if there are issues with the API.
+# Instead, catch timeout exceptions and retry the request until it succeeds or a different exception is raised.
+
 TIMEOUT=1800
 
 def _make_url(endpoint):

--- a/backend/connectors/nmbgmr/source.py
+++ b/backend/connectors/nmbgmr/source.py
@@ -44,6 +44,11 @@ from backend.source import (
     make_site_list,
 )
 
+"""
+Set timeout to 30 minutes for analyte and water level requests since some sites have a large number of records and the NMBGMR API can be slow to respond.
+Don't use timeout=None since that can cause the request to hang indefinitely if there are issues with the API. Instead, catch timeout exceptions and retry the request until it succeeds or a different exception is raised.
+"""
+TIMEOUT=1800
 
 def _make_url(endpoint):
     if os.getenv("DEBUG") == "1":
@@ -83,9 +88,16 @@ class NMBGMRSiteSource(BaseSiteSource):
                 params["parameter"] = "Manual groundwater levels"
 
         # tags="features" because the response object is a GeoJSON
-        sites = self._execute_json_request(
-            _make_url("locations"), params, tag="features", timeout=30
-        )
+        request_finished: bool = False
+        while not request_finished:
+            try:
+                sites = self._execute_json_request(
+                    _make_url("locations"), params, tag="features", timeout=TIMEOUT
+                )
+                request_finished = True
+            except Exception as e:
+                self.warning(f"Error retrieving site data: {e}. Retrying...")
+
         if not config.sites_only:
             for site in sites:
                 if get_bool_env_variable("IS_TESTING_ENV"):
@@ -119,14 +131,23 @@ class NMBGMRAnalyteSource(BaseAnalyteSource):
         analyte = get_analyte_search_param(
             self.config.parameter, NMBGMR_ANALYTE_MAPPING
         )
-        records = self._execute_json_request(
-            _make_url("waterchemistry"),
-            params={
-                "pointid": ",".join(make_site_list(site_record)),
-                "analyte": analyte,
-            },
-            tag="",
-        )
+
+        request_finished: bool = False
+
+        while not request_finished:
+            try:
+                records = self._execute_json_request(
+                    _make_url("waterchemistry"),
+                    params={
+                        "pointid": ",".join(make_site_list(site_record)),
+                        "analyte": analyte,
+                    },
+                    tag="",
+                    timeout=TIMEOUT
+                )
+                request_finished = True
+            except Exception as e:
+                self.warning(f"Error retrieving analyte data: {e}. Retrying...")
         records_sorted_by_pointid = {}
         for pointid in records.keys():
             records_sorted_by_pointid[pointid] = records[pointid][analyte]
@@ -221,10 +242,17 @@ class NMBGMRWaterLevelSource(BaseWaterLevelSource):
         #     url = _make_url("waterlevels/latest")
         # else:
         params = {"pointid": ",".join(make_site_list(site_record))}
+        print(make_site_list(site_record))
         # just use manual waterlevels temporarily
         url = _make_url("waterlevels/manual")
 
-        paginated_records = self._execute_json_request(url, params, tag="")
+        request_finished: bool = False
+        while not request_finished:
+             try:
+                paginated_records = self._execute_json_request(url, params, tag="", timeout=TIMEOUT)
+                request_finished = True
+             except Exception as e:
+                self.warning(f"Error retrieving water level data: {e}. Retrying...")
         items = paginated_records["items"]
         page = paginated_records["page"]
         pages = paginated_records["pages"]
@@ -232,7 +260,19 @@ class NMBGMRWaterLevelSource(BaseWaterLevelSource):
         while page < pages:
             page += 1
             params["page"] = page
-            new_records = self._execute_json_request(url, params, tag="")
+
+            request_finished: bool = False
+            while not request_finished:
+                try:
+                    new_records = self._execute_json_request(url, params, tag="", timeout=TIMEOUT)
+                    # status_code != 200 makes _execute_json_request return None, so check for that and retry if it happens
+                    if new_records is None:
+                        self.warning("Retrying...")
+                        continue
+                    request_finished = True
+                except Exception as e:
+                    self.warning(f"Error retrieving page {page} of water level data: {e}. Retrying...")
+            
             items.extend(new_records["items"])
             pages = new_records["pages"]
 

--- a/backend/connectors/nmbgmr/source.py
+++ b/backend/connectors/nmbgmr/source.py
@@ -68,10 +68,13 @@ class NMBGMRSiteSource(BaseSiteSource):
         return "NMBGMRSiteSource"
 
     def health(self):
-        resp = self._execute_json_request(
-            _make_url("locations"), tag="features", params={"limit": 1}
-        )
-        return bool(resp)
+        try:
+            resp = self._execute_json_request(
+                _make_url("locations"), tag="features", params={"limit": 1}
+            )
+            return True
+        except Exception:
+            return False
 
     def get_records(self):
         config = self.config

--- a/backend/connectors/nmbgmr/source.py
+++ b/backend/connectors/nmbgmr/source.py
@@ -45,9 +45,9 @@ from backend.source import (
 )
 
 
-# Set timeout to 30 minutes for analyte and water level requests since some sites have a large number of records and the NMBGMR API can be slow to respond.
+# Set timeout to 15 minutes for analyte and water level requests since some sites have a large number of records and the NMBGMR API can be slow to respond.
 # Don't use timeout=None since that can cause the request to hang indefinitely if there are issues with the API.
-# Instead, catch timeout exceptions and retry the request until it succeeds or a different exception is raised.
+# Instead, catch timeout and other exceptions and retry the request up to 7 times with a delay between retries.
 
 TIMEOUT=15*60
 

--- a/backend/connectors/nmbgmr/source.py
+++ b/backend/connectors/nmbgmr/source.py
@@ -72,7 +72,7 @@ class NMBGMRSiteSource(BaseSiteSource):
             resp = self._execute_json_request(
                 _make_url("locations"), tag="features", params={"limit": 1}
             )
-            return True
+            return bool(resp)
         except Exception:
             return False
 

--- a/backend/connectors/nmenv/source.py
+++ b/backend/connectors/nmenv/source.py
@@ -45,8 +45,12 @@ class DWBSiteSource(STSiteSource):
         return "DWBSiteSource"
 
     def health(self):
-        return self.get_records(top=10, analyte=TDS)
-
+        try:
+            self.get_records(top=10, analyte=TDS)
+            return True
+        except Exception:
+            return False
+            
     def get_records(self, *args, **kw):
 
         analyte = None

--- a/backend/connectors/nmenv/source.py
+++ b/backend/connectors/nmenv/source.py
@@ -46,9 +46,7 @@ class DWBSiteSource(STSiteSource):
 
     def health(self):
         try:
-            # Health checks may run before config is initialized; probe the service directly.
-            service = self.get_service()
-            resp = list(service.locations().query().top(1).list())
+            resp = self.get_records(top=10, analyte=TDS)
             return bool(resp)
         except Exception:
             return False

--- a/backend/connectors/nmenv/source.py
+++ b/backend/connectors/nmenv/source.py
@@ -46,8 +46,8 @@ class DWBSiteSource(STSiteSource):
 
     def health(self):
         try:
-            self.get_records(top=10, analyte=TDS)
-            return True
+            resp = self.get_records(top=10, analyte=TDS)
+            return bool(resp)
         except Exception:
             return False
             

--- a/backend/connectors/nmenv/source.py
+++ b/backend/connectors/nmenv/source.py
@@ -46,7 +46,9 @@ class DWBSiteSource(STSiteSource):
 
     def health(self):
         try:
-            resp = self.get_records(top=10, analyte=TDS)
+            # Health checks may run before config is initialized; probe the service directly.
+            service = self.get_service()
+            resp = list(service.locations().query().top(1).list())
             return bool(resp)
         except Exception:
             return False

--- a/backend/connectors/st_connector.py
+++ b/backend/connectors/st_connector.py
@@ -91,7 +91,9 @@ def make_dt_filter(tag, start, end):
 class STSiteSource(BaseSiteSource, STSource):
     def health(self):
         try:
-            resp = self.get_records(top=10)
+            # Health checks may run before config is initialized; probe the service directly.
+            service = self.get_service()
+            resp = list(service.locations().query().top(1).list())
             return bool(resp)
         except Exception:
             return False

--- a/backend/connectors/st_connector.py
+++ b/backend/connectors/st_connector.py
@@ -90,8 +90,12 @@ def make_dt_filter(tag, start, end):
 
 class STSiteSource(BaseSiteSource, STSource):
     def health(self):
-        return self.get_records(top=10)
-
+        try:
+            self.get_records(top=10)
+            return True
+        except Exception:
+            return False
+            
     def get_records(self, *args, **kw):
         service = self.get_service()
 

--- a/backend/connectors/st_connector.py
+++ b/backend/connectors/st_connector.py
@@ -91,8 +91,8 @@ def make_dt_filter(tag, start, end):
 class STSiteSource(BaseSiteSource, STSource):
     def health(self):
         try:
-            self.get_records(top=10)
-            return True
+            resp = self.get_records(top=10)
+            return bool(resp)
         except Exception:
             return False
             

--- a/backend/connectors/usgs/source.py
+++ b/backend/connectors/usgs/source.py
@@ -154,7 +154,7 @@ class NWISWaterLevelSource(BaseWaterLevelSource):
                         json=json_data,
                         headers={"X-API-Key": KEY, "Content-Type": "application/query-cql-json"},
                         params={"limit": LIMIT, "parameter_code": "72019"},
-                        timeout=None,
+                        timeout=TIMEOUT,
                     )
                     if response.status_code != 200:
                         self.warning(f"Received status code {response.status_code} for sites {list_of_sites}. Retrying...")
@@ -186,11 +186,21 @@ class NWISWaterLevelSource(BaseWaterLevelSource):
             # use GET requests for the paginated responses after the initial POST to avoid issues with httpx and long URLs with many site ids
             # USGS APIs use cursor pagination, so we can just follow the "next" links until there are no more
             while found_next_link:
-                response = httpx.get(
-                    url=next_link_url,
-                    headers={"X-API-Key": KEY, "Content-Type": "application/query-cql-json"},
-                    timeout=None,
-                )
+                finished_request: bool = False
+                while not finished_request:
+                    try:
+                        response = httpx.get(
+                                url=next_link_url,
+                                headers={"X-API-Key": KEY, "Content-Type": "application/query-cql-json"},
+                                timeout=TIMEOUT,
+                            )
+                        if response.status_code != 200:
+                            self.warning(f"Received status code {response.status_code} for paginated request. Retrying...")
+                        else:
+                            finished_request = True
+                    except Exception as e:
+                        self.warning(f"Error retrieving paginated water level records: {e}. Retrying...
+                        
                 data: dict = response.json()
                 features: list[dict] = data.get("features", [])
                 standard_features: list[dict] = [self._standardize_record(feature) for feature in features]

--- a/backend/connectors/usgs/source.py
+++ b/backend/connectors/usgs/source.py
@@ -69,7 +69,7 @@ class NWISSiteSource(BaseSiteSource):
         )
             return True
         except httpx.HTTPStatusError:
-            pass
+            return False
 
     def get_records(self):
         # TODO: handle date filters

--- a/backend/connectors/usgs/source.py
+++ b/backend/connectors/usgs/source.py
@@ -61,12 +61,12 @@ class NWISSiteSource(BaseSiteSource):
 
     def health(self):
         try:
-            data = self._execute_json_request(
-            url=self.sites_url,
-            params={"limit": LIMIT, "parameter_code": "72019", "site_type_code": "GW", "state_code": "35"},
-            timeout=None,
-            headers={"X-API-Key": KEY},
-        )
+            self._execute_json_request(
+                url=self.sites_url,
+                params={"limit": 1, "parameter_code": "72019", "site_type_code": "GW", "state_code": "35"},
+                timeout=TIMEOUT,
+                headers={"X-API-Key": KEY},
+            )
             return True
         except httpx.HTTPStatusError:
             return False

--- a/backend/connectors/usgs/source.py
+++ b/backend/connectors/usgs/source.py
@@ -92,11 +92,11 @@ class NWISSiteSource(BaseSiteSource):
                 )
                 # _execute_json_request returns None for non-200 responses, so we need to check for that as well
                 if data is None:
-                    self.warning("Retrying...")
+                    self.warn("Retrying...")
                 else:
                     finished_request = True
             except Exception as e:
-                self.warning(f"Error retrieving site records: {e}. Retrying...")
+                self.warn(f"Error retrieving site records: {e}. Retrying...")
 
         records: list = data.get("features", [])
 
@@ -152,11 +152,11 @@ class NWISWaterLevelSource(BaseWaterLevelSource):
                         timeout=TIMEOUT,
                     )
                     if response.status_code != 200:
-                        self.warning(f"Received status code {response.status_code}. Retrying...")
+                        self.warn(f"Received status code {response.status_code}. Retrying...")
                     else:
                         finished_request = True
                 except Exception as e:
-                    self.warning(f"Error retrieving water level records: {e}. Retrying...")
+                    self.warn(f"Error retrieving water level records: {e}. Retrying...")
 
             data: dict = response.json()
             features: list[dict] = data.get("features", [])
@@ -190,11 +190,11 @@ class NWISWaterLevelSource(BaseWaterLevelSource):
                                 timeout=TIMEOUT,
                             )
                         if response.status_code != 200:
-                            self.warning(f"Received status code {response.status_code} for paginated request. Retrying...")
+                            self.warn(f"Received status code {response.status_code} for paginated request. Retrying...")
                         else:
                             finished_request = True
                     except Exception as e:
-                        self.warning(f"Error retrieving paginated water level records: {e}. Retrying...
+                        self.warn(f"Error retrieving paginated water level records: {e}. Retrying...
                         
                 data: dict = response.json()
                 features: list[dict] = data.get("features", [])

--- a/backend/connectors/usgs/source.py
+++ b/backend/connectors/usgs/source.py
@@ -17,24 +17,19 @@ import httpx
 
 from backend.connectors import NM_STATE_BOUNDING_POLYGON
 from backend.constants import (
-    FEET,
     DTW,
-    DTW_UNITS,
     DT_MEASURED,
     PARAMETER_NAME,
     PARAMETER_VALUE,
     PARAMETER_UNITS,
     SOURCE_PARAMETER_NAME,
     SOURCE_PARAMETER_UNITS,
-    EARLIEST,
-    LATEST,
 )
 from backend.connectors.usgs.transformer import (
     NWISSiteTransformer,
     NWISWaterLevelTransformer,
 )
 from backend.source import (
-    BaseSource,
     BaseWaterLevelSource,
     BaseSiteSource,
     make_site_list,

--- a/backend/connectors/usgs/source.py
+++ b/backend/connectors/usgs/source.py
@@ -44,6 +44,7 @@ from backend.source import (
 
 KEY = "55MILtQrayXw1NgufxcqRfkkRrg4Rg6KNCyJZ004"
 LIMIT = 50000    
+TIMEOUT=1800
 
 class NWISSiteSource(BaseSiteSource):
     transformer_klass = NWISSiteTransformer
@@ -85,12 +86,22 @@ class NWISSiteSource(BaseSiteSource):
         # if config.end_date:
         #     params["endDt"] = config.end_dt.date().isoformat()
 
-        data = self._execute_json_request(
-            url=self.sites_url,
-            params={"limit": LIMIT, "parameter_code": "72019", "site_type_code": "GW", "state_code": "35"},
-            timeout=None,
-            headers={"X-API-Key": KEY},
-        )
+        finished_request: bool = False
+        while not finished_request:
+            try:
+                data = self._execute_json_request(
+                    url=self.sites_url,
+                    params={"limit": LIMIT, "parameter_code": "72019", "site_type_code": "GW", "state_code": "35"},
+                    timeout=TIMEOUT,
+                    headers={"X-API-Key": KEY},
+                )
+                # _execute_json_request returns None for non-200 responses, so we need to check for that as well
+                if data is None:
+                    self.warning("Retrying...")
+                else:
+                    finished_request = True
+            except Exception as e:
+                self.warning(f"Error retrieving site records: {e}. Retrying...")
 
         records: list = data.get("features", [])
 
@@ -135,14 +146,23 @@ class NWISWaterLevelSource(BaseWaterLevelSource):
                     list_of_sites
                 ]
             }
+            finished_request: bool = False
+            while not finished_request:
+                try:
+                    response = httpx.post(
+                        url="https://api.waterdata.usgs.gov/ogcapi/v0/collections/field-measurements/items",
+                        json=json_data,
+                        headers={"X-API-Key": KEY, "Content-Type": "application/query-cql-json"},
+                        params={"limit": LIMIT, "parameter_code": "72019"},
+                        timeout=None,
+                    )
+                    if response.status_code != 200:
+                        self.warning(f"Received status code {response.status_code} for sites {list_of_sites}. Retrying...")
+                    else:
+                        finished_request = True
+                except Exception as e:
+                    self.warning(f"Error retrieving water level records: {e}. Retrying...")
 
-            response = httpx.post(
-                url="https://api.waterdata.usgs.gov/ogcapi/v0/collections/field-measurements/items",
-                json=json_data,
-                headers={"X-API-Key": KEY, "Content-Type": "application/query-cql-json"},
-                params={"limit": LIMIT, "parameter_code": "72019"},
-                timeout=None,
-            )
             data: dict = response.json()
             features: list[dict] = data.get("features", [])
 

--- a/backend/connectors/usgs/source.py
+++ b/backend/connectors/usgs/source.py
@@ -157,7 +157,7 @@ class NWISWaterLevelSource(BaseWaterLevelSource):
                         timeout=TIMEOUT,
                     )
                     if response.status_code != 200:
-                        self.warning(f"Received status code {response.status_code} for sites {list_of_sites}. Retrying...")
+                        self.warning(f"Received status code {response.status_code}. Retrying...")
                     else:
                         finished_request = True
                 except Exception as e:

--- a/backend/connectors/usgs/source.py
+++ b/backend/connectors/usgs/source.py
@@ -41,133 +41,14 @@ from backend.source import (
     get_terminal_record,
 )
 
-"""
--- sites --
-https://api.waterdata.usgs.gov/ogcapi/v0/collections/combined-metadata/items?
-state_code=35
-site_type_code=GW
-parameter_code=72019
-
--- water levels --
-https://api.waterdata.usgs.gov/ogcapi/v0/collections/field-measurements/items?
-monitoring_location_id=<>&monitoring_location_id=<>...
-
-parameter_code=72019
-"""
 
 KEY = "55MILtQrayXw1NgufxcqRfkkRrg4Rg6KNCyJZ004"
-
-def transform_usgs_waterlevels_record(record: dict) -> dict:
-    return {
-        "site_id": record["properties"]["monitoring_location_id"],
-        "source_parameter_name": "Water level, depth LSD",
-        "value": record["properties"]["value"],
-        "datetime_measured": record["properties"]["time"],
-        "source_parameter_units": record["properties"]["unit_of_measure"]
-    }
-
-def retrieve_usgs_data(
-    url: str,
-    json_data: dict,
-    headers: dict = None,
-    params: dict = None,
-    timeout: int = None,
-    transformation_hook=None
-) -> list:
-    """
-    Start with a POST request to retrieve the initial batch of data using complex queries, then
-    follow the "next" links in the response to retrieve all paginated data with GET requests.
-
-    The transformation_hook can be used to transform each batch of records as they are retrieved
-    """
-    records: list = []
-
-    response = httpx.post(
-        url=url,
-        json=json_data,
-        headers=headers,
-        params=params,
-        timeout=timeout,
-    )
-    data: dict = response.json()
-    features: list[dict] = data.get("features", [])
-
-    if transformation_hook:
-        transformed_features = [transformation_hook(feature) for feature in features]
-        records.extend(transformed_features)
-    else:
-        records.extend(features)
-    
-    # print(f"Retrieved {len(records)} records")
-
-    found_next_link: bool = False
-    links: list = data.get("links", [])
-    for link in links:
-        if link["rel"] == "next":
-            next_link_url = link["href"]
-            found_next_link = True
-            break
-
-    # use GET requests for the paginated responses after the initial POST to avoid issues with httpx and long URLs with many site ids
-    # USGS APIs use cursor pagination, so we can just follow the "next" links until there are no more
-    while found_next_link:
-        # print(f"Following next link: {next_link_url}")
-        response = httpx.get(
-            url=next_link_url,
-            headers=headers,
-            timeout=timeout,
-        )
-        data: dict = response.json()
-        features = data.get("features", [])
-        if transformation_hook:
-            transformed_features = [transformation_hook(feature) for feature in features]
-            records.extend(transformed_features)
-        else:
-            records.extend(features)
-        
-        # print(f"Retrieved {len(records)} records")
-
-        found_next_link: bool = False
-        links: list = data.get("links", [])
-        for link in links:
-            if link["rel"] == "next":
-                next_link_url = link["href"]
-                found_next_link = True
-                break
-
-    return records
-
+LIMIT = 50000    
 
 class NWISSiteSource(BaseSiteSource):
     transformer_klass = NWISSiteTransformer
     chunk_size = 500
     bounding_polygon = NM_STATE_BOUNDING_POLYGON
-    json_data: dict = {
-        "op": "and",
-        "args": [
-            {
-                "op": "in",
-                "args": [
-                    {"property": "state_code"},
-                    ["35"]
-                ]
-            },
-            {
-                "op": "in",
-                "args": [
-                    {"property": "site_type_code"},
-                    ["GW"]
-                ]
-            },
-            {
-                "op": "in",
-                "args": [
-                    {"property": "parameter_code"},
-                    ["72019"]
-                ]
-            }
-        ]
-    }
 
     def __repr__(self):
         return "NWISSiteSource"
@@ -206,7 +87,7 @@ class NWISSiteSource(BaseSiteSource):
 
         data = self._execute_json_request(
             url=sites_url,
-            params={"limit": 50000, "parameter_code": "72019", "site_type_code": "GW", "state_code": "35"},
+            params={"limit": LIMIT, "parameter_code": "72019", "site_type_code": "GW", "state_code": "35"},
             timeout=None,
             headers={"X-API-Key": KEY},
         )
@@ -240,7 +121,7 @@ class NWISWaterLevelSource(BaseWaterLevelSource):
         sites: list = make_site_list(site_record)
 
         # group sites into batches of num_sites to pass to the API
-        # since USGS APIs allow up to 250 sites to be queried at once with complex queries
+        # USGS APIs allow up to 250 sites to be queried at once with complex queries
         list_of_lists_of_sites: list = []
         for i in range(0, len(sites), self.num_sites):
             list_of_lists_of_sites.append(sites[i:i + self.num_sites]) 
@@ -255,19 +136,67 @@ class NWISWaterLevelSource(BaseWaterLevelSource):
                 ]
             }
 
-            records_batch: list = retrieve_usgs_data(
+            response = httpx.post(
                 url="https://api.waterdata.usgs.gov/ogcapi/v0/collections/field-measurements/items",
-                json_data=json_data,
+                json=json_data,
                 headers={"X-API-Key": KEY, "Content-Type": "application/query-cql-json"},
-                params={"limit": 50000, "parameter_code": "72019"},
+                params={"limit": LIMIT, "parameter_code": "72019"},
                 timeout=None,
-                transformation_hook=transform_usgs_waterlevels_record
             )
-            records.extend(records_batch)
+            data: dict = response.json()
+            features: list[dict] = data.get("features", [])
+
+            standard_features: list[dict] = [self._standardize_record(feature) for feature in features]
+            records.extend(standard_features)
+            
+            """
+            The following commented-out code handles pagination for cases where there are more than LIMIT records for a given batch of sites.
+            However, in testing, I have not encountered any cases where this is necessary. Furthermore, cursor-based pagination is broken as
+            of 4/29/26 when the limit query parameter is used, and it can't be used in combination with other parameters via complex queries.
+            If we do encounter cases where there are more than LIMIT records, we can use the following code to handle pagination (when it is fixed).
+            
+            found_next_link: bool = False
+            links: list[dict] = data.get("links", [])
+            for link in links:
+                if link["rel"] == "next":
+                    next_link_url = link["href"]
+                    found_next_link = True
+                    break
+
+            # use GET requests for the paginated responses after the initial POST to avoid issues with httpx and long URLs with many site ids
+            # USGS APIs use cursor pagination, so we can just follow the "next" links until there are no more
+            while found_next_link:
+                response = httpx.get(
+                    url=next_link_url,
+                    headers={"X-API-Key": KEY, "Content-Type": "application/query-cql-json"},
+                    timeout=None,
+                )
+                data: dict = response.json()
+                features: list[dict] = data.get("features", [])
+                standard_features: list[dict] = [self._standardize_record(feature) for feature in features]
+                records.extend(standard_features)
+                
+                found_next_link: bool = False
+                links: list = data.get("links", [])
+                for link in links:
+                    if link["rel"] == "next":
+                        next_link_url = link["href"]
+                        found_next_link = True
+                        break
+            """
 
         self.log(f"Retrieved {len(records)} records")
 
         return records
+    
+    def _standardize_record(self, record: dict) -> dict:
+        return {
+            "site_id": record["properties"]["monitoring_location_id"],
+            "source_parameter_name": "Water level, depth LSD",
+            "value": record["properties"]["value"],
+            "datetime_measured": record["properties"]["time"],
+            "source_parameter_units": record["properties"]["unit_of_measure"]
+        }
 
     def _extract_site_records(self, records, site_record):
         return [ri for ri in records if ri["site_id"] == site_record.id]

--- a/backend/connectors/usgs/source.py
+++ b/backend/connectors/usgs/source.py
@@ -43,9 +43,10 @@ from backend.source import (
 
 """
 -- sites --
-https://api.waterdata.usgs.gov/ogcapi/v0/collections/monitoring-locations/items?
+https://api.waterdata.usgs.gov/ogcapi/v0/collections/combined-metadata/items?
 state_code=35
 site_type_code=GW
+parameter_code=72019
 
 -- water levels --
 https://api.waterdata.usgs.gov/ogcapi/v0/collections/field-measurements/items?
@@ -56,19 +57,117 @@ parameter_code=72019
 
 KEY = "55MILtQrayXw1NgufxcqRfkkRrg4Rg6KNCyJZ004"
 
-def parse_waterlevels_json(data):
-    """
-    Parses JSON responses for USGS field measurements (water levels) into a list of records with standardized keys.
-    """
-    records = []
+def transform_usgs_waterlevels_record(record: dict) -> dict:
+    return {
+        "site_id": record["properties"]["monitoring_location_id"],
+        "source_parameter_name": "Water level, depth LSD",
+        "value": record["properties"]["value"],
+        "datetime_measured": record["properties"]["time"],
+        "source_parameter_units": record["properties"]["unit_of_measure"]
+    }
 
+def retrieve_usgs_data(
+    url: str,
+    json_data: dict,
+    headers: dict = None,
+    params: dict = None,
+    timeout: int = None,
+    transformation_hook=None
+) -> list:
+    """
+    Start with a POST request to retrieve the initial batch of data using complex queries, then
+    follow the "next" links in the response to retrieve all paginated data with GET requests.
+
+    The transformation_hook can be used to transform each batch of records as they are retrieved
+    """
+    records: list = []
+
+    response = httpx.post(
+        url=url,
+        json=json_data,
+        headers=headers,
+        params=params,
+        timeout=timeout,
+    )
+    data: dict = response.json()
+    features: list[dict] = data.get("features", [])
+
+    if transformation_hook:
+        transformed_features = [transformation_hook(feature) for feature in features]
+        records.extend(transformed_features)
+    else:
+        records.extend(features)
     
+    # print(f"Retrieved {len(records)} records")
+
+    found_next_link: bool = False
+    links: list = data.get("links", [])
+    for link in links:
+        if link["rel"] == "next":
+            next_link_url = link["href"]
+            found_next_link = True
+            break
+
+    # use GET requests for the paginated responses after the initial POST to avoid issues with httpx and long URLs with many site ids
+    # USGS APIs use cursor pagination, so we can just follow the "next" links until there are no more
+    while found_next_link:
+        # print(f"Following next link: {next_link_url}")
+        response = httpx.get(
+            url=next_link_url,
+            headers=headers,
+            timeout=timeout,
+        )
+        data: dict = response.json()
+        features = data.get("features", [])
+        if transformation_hook:
+            transformed_features = [transformation_hook(feature) for feature in features]
+            records.extend(transformed_features)
+        else:
+            records.extend(features)
+        
+        # print(f"Retrieved {len(records)} records")
+
+        found_next_link: bool = False
+        links: list = data.get("links", [])
+        for link in links:
+            if link["rel"] == "next":
+                next_link_url = link["href"]
+                found_next_link = True
+                break
+
+    return records
 
 
 class NWISSiteSource(BaseSiteSource):
     transformer_klass = NWISSiteTransformer
     chunk_size = 500
     bounding_polygon = NM_STATE_BOUNDING_POLYGON
+    json_data: dict = {
+        "op": "and",
+        "args": [
+            {
+                "op": "in",
+                "args": [
+                    {"property": "state_code"},
+                    ["35"]
+                ]
+            },
+            {
+                "op": "in",
+                "args": [
+                    {"property": "site_type_code"},
+                    ["GW"]
+                ]
+            },
+            {
+                "op": "in",
+                "args": [
+                    {"property": "parameter_code"},
+                    ["72019"]
+                ]
+            }
+        ]
+    }
 
     def __repr__(self):
         return "NWISSiteSource"
@@ -79,145 +178,94 @@ class NWISSiteSource(BaseSiteSource):
 
     def health(self):
         try:
-            params = {
-                "state_code": "35",
-                "site_type_code": "GW"
-            }
-            self._execute_json_request(
-                url="https://api.waterdata.usgs.gov/ogcapi/v0/collections/monitoring-locations/items",
-                params=params
+            httpx.post(
+                url="https://api.waterdata.usgs.gov/ogcapi/v0/collections/combined-metadata/items",
+                data=self.json_data,
+                headers={"X-API-Key": KEY, "Content-Type": "application/query-cql-json"},
+                timeout=None
             )
             return True
         except httpx.HTTPStatusError:
             pass
 
     def get_records(self):
-        params = {
-            "site_type_code": "GW",
-            "limit": self.chunk_size,
-        }
-        config = self.config
+        # TODO: handle date filters
+        # config = self.config
 
-        if config.has_bounds():
-            bbox = config.bbox_bounding_points()
-            params["bbox"] = ",".join([str(b) for b in bbox])
-        else:
-            params["state_code"] = "35"
+        # if config.has_bounds():
+        #     bbox = config.bbox_bounding_points()
+        #     params["bbox"] = ",".join([str(b) for b in bbox])
+        # else:
+        #     params["state_code"] = "35"
 
         # if config.start_date:
         #     params["startDt"] = config.start_dt.date().isoformat()
         # if config.end_date:
         #     params["endDt"] = config.end_dt.date().isoformat()
+        sites_url: str = "https://api.waterdata.usgs.gov/ogcapi/v0/collections/combined-metadata/items"
 
-        reached_end: bool = False
-        records: list = []
-        sites_url: str = "https://api.waterdata.usgs.gov/ogcapi/v0/collections/monitoring-locations/items"
+        data = self._execute_json_request(
+            url=sites_url,
+            params={"limit": 50000, "parameter_code": "72019", "site_type_code": "GW", "state_code": "35"},
+            timeout=None,
+            headers={"X-API-Key": KEY},
+        )
 
-        """
-        TODO
-
-        update the site transformer to transform into standardized format
-        """
-
-        while not reached_end:
-            response = self._execute_json_request(
-                url=sites_url,
-                params=params,
-                headers={"X-API-Key": KEY}
-            )
-
-            records.extend(response.get("features", []))
-
-            found_next_link: bool = False
-            for link in response["links"]:
-                if link["rel"] == "next":
-                    sites_url = link["href"]
-                    params = None  # next link already has params encoded
-                    found_next_link = True
-                    break
-            
-            if not found_next_link  :
-                reached_end = True
-           
+        records: list = data.get("features", [])
 
         return records
 
 
-# TODO: IMPLEMENT! and transform as necessary. keep in mind "next" links for pagination
-
 class NWISWaterLevelSource(BaseWaterLevelSource):
     transformer_klass = NWISWaterLevelTransformer
-    # chunk_size=5 to avoid URI length and httpx read timed out issue
-    chunk_size = 5
+    # USGS complex queries allow up to 250 sites to be queried at once
+    # https://api.waterdata.usgs.gov/docs/ogcapi/complex-queries
+    num_sites = 250
 
     def __repr__(self):
         return "NWISWaterLevelSource"
 
     def get_records(self, site_record):
-        records: list = []
+        # TODO: handle date filters
+        # config = self.config
+        # if config.start_date:
+        #     params["startDt"] = config.start_dt.date().isoformat()
+        # else:
+        #     params["startDt"] = "1900-01-01"
 
-        # if more than 5 sites are provided the URI is too long
+        # if config.end_date:
+        #     params["endDt"] = config.end_dt.date().isoformat()
+
+        records: list = []
         sites: list = make_site_list(site_record)
 
-        # chunk the sites into groups of 5 to avoid URI length issues
-        chunks_of_sites: list = []
-        for i in range(0, len(sites), self.chunk_size):
-            chunks_of_sites.append(sites[i:i + self.chunk_size]) 
+        # group sites into batches of num_sites to pass to the API
+        # since USGS APIs allow up to 250 sites to be queried at once with complex queries
+        list_of_lists_of_sites: list = []
+        for i in range(0, len(sites), self.num_sites):
+            list_of_lists_of_sites.append(sites[i:i + self.num_sites]) 
 
 
-        for chunked_sites in chunks_of_sites:
-            delineated_sites: str = ",".join(chunked_sites)
-        
-            obs_url: str = "https://api.waterdata.usgs.gov/ogcapi/v0/collections/field-measurements/items"
-
-            reached_end: bool = False
-
-            params: dict = {
-                "parameter_code": "72019",
-                "monitoring_location_id": delineated_sites,
-                "limit": 500,
+        for list_of_sites in list_of_lists_of_sites:
+            json_data: dict = {
+                "op": "in",
+                "args": [
+                    {"property": "monitoring_location_id"},
+                    list_of_sites
+                ]
             }
 
-            config = self.config
-            # if config.start_date:
-            #     params["startDt"] = config.start_dt.date().isoformat()
-            # else:
-            #     params["startDt"] = "1900-01-01"
+            records_batch: list = retrieve_usgs_data(
+                url="https://api.waterdata.usgs.gov/ogcapi/v0/collections/field-measurements/items",
+                json_data=json_data,
+                headers={"X-API-Key": KEY, "Content-Type": "application/query-cql-json"},
+                params={"limit": 50000, "parameter_code": "72019"},
+                timeout=None,
+                transformation_hook=transform_usgs_waterlevels_record
+            )
+            records.extend(records_batch)
 
-            # if config.end_date:
-            #     params["endDt"] = config.end_dt.date().isoformat()
-
-            while not reached_end:
-                response = self._execute_json_request(
-                    url=obs_url,
-                    params=params,
-                    headers={"X-API-Key": KEY}
-                )
-
-                data: list[dict] = response.get("features", [])
-                if data:
-                    for feature in data:
-                        record = {
-                            "site_id": feature["properties"]["monitoring_location_id"],
-                            "source_parameter_name": "Water level, depth LSD",
-                            "value": feature["properties"]["value"],
-                            "datetime_measured": feature["properties"]["time"],
-                            "source_parameter_units": feature["properties"]["unit_of_measure"]
-                        }
-                        records.append(record)
-
-                found_next_link: bool = False
-                for link in response["links"]:
-                    if link["rel"] == "next":
-                        obs_url = link["href"]
-                        params = None  # next link already has params encoded
-                        found_next_link = True
-                        break
-                
-                if not found_next_link  :
-                    reached_end = True
         self.log(f"Retrieved {len(records)} records")
-
 
         return records
 

--- a/backend/connectors/usgs/source.py
+++ b/backend/connectors/usgs/source.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ===============================================================================
-from datetime import datetime
 import httpx
 
 from backend.connectors import NM_STATE_BOUNDING_POLYGON
@@ -42,55 +41,28 @@ from backend.source import (
     get_terminal_record,
 )
 
+"""
+-- sites --
+https://api.waterdata.usgs.gov/ogcapi/v0/collections/monitoring-locations/items?
+state_code=35
+site_type_code=GW
 
-def parse_rdb(text):
-    """'
-    Parses rdb tab-delimited responses for NWIS Site Services
+-- water levels --
+https://api.waterdata.usgs.gov/ogcapi/v0/collections/field-measurements/items?
+monitoring_location_id=<>&monitoring_location_id=<>...
+
+parameter_code=72019
+"""
+
+KEY = "55MILtQrayXw1NgufxcqRfkkRrg4Rg6KNCyJZ004"
+
+def parse_waterlevels_json(data):
     """
-
-    def line_generator():
-        header = None
-        for line in text.split("\n"):
-            if line.startswith("#"):
-                continue
-            elif line.startswith("agency_cd"):
-                header = [h.strip() for h in line.split("\t")]
-                continue
-            elif line.startswith("5s"):
-                continue
-            elif line == "":
-                continue
-
-            vals = [v.strip() for v in line.split("\t")]
-            if header and any(vals):
-                yield dict(zip(header, vals))
-
-    return list(line_generator())
-
-
-def parse_json(data):
-    """
-    Parses JSON responses for NWIS Groundwater Level Services
+    Parses JSON responses for USGS field measurements (water levels) into a list of records with standardized keys.
     """
     records = []
 
-    for location in data["timeSeries"]:
-        site_code = location["sourceInfo"]["siteCode"][0]["value"]
-        agency = location["sourceInfo"]["siteCode"][0]["agencyCode"]
-        source_parameter_name = location["variable"]["variableName"]
-        source_parameter_units = location["variable"]["unit"]["unitCode"]
-        for value in location["values"][0]["value"]:
-            record = {
-                "site_id": f"{agency}-{site_code}",
-                "source_parameter_name": source_parameter_name,
-                "value": value["value"],
-                "datetime_measured": value["dateTime"],
-                # "date_measured": value["dateTime"].split("T")[0],
-                # "time_measured": value["dateTime"].split("T")[1],
-                "source_parameter_units": source_parameter_units,
-            }
-            records.append(record)
-    return records
+    
 
 
 class NWISSiteSource(BaseSiteSource):
@@ -107,80 +79,147 @@ class NWISSiteSource(BaseSiteSource):
 
     def health(self):
         try:
-            self._execute_text_request(
-                "https://waterservices.usgs.gov/nwis/site/",
-                {
-                    "format": "rdb",
-                    "siteOutput": "expanded",
-                    "siteType": "GW",
-                    "site": "325754103461301",
-                },
+            params = {
+                "state_code": "35",
+                "site_type_code": "GW"
+            }
+            self._execute_json_request(
+                url="https://api.waterdata.usgs.gov/ogcapi/v0/collections/monitoring-locations/items",
+                params=params
             )
             return True
         except httpx.HTTPStatusError:
             pass
 
     def get_records(self):
-        params = {"format": "rdb", "siteOutput": "expanded", "siteType": "GW"}
+        params = {
+            "site_type_code": "GW",
+            "limit": self.chunk_size,
+        }
         config = self.config
 
         if config.has_bounds():
             bbox = config.bbox_bounding_points()
-            params["bBox"] = ",".join([str(b) for b in bbox])
+            params["bbox"] = ",".join([str(b) for b in bbox])
         else:
-            params["stateCd"] = "NM"
+            params["state_code"] = "35"
 
-        if config.start_date:
-            params["startDt"] = config.start_dt.date().isoformat()
-        if config.end_date:
-            params["endDt"] = config.end_dt.date().isoformat()
+        # if config.start_date:
+        #     params["startDt"] = config.start_dt.date().isoformat()
+        # if config.end_date:
+        #     params["endDt"] = config.end_dt.date().isoformat()
 
-        text = self._execute_text_request(
-            "https://waterservices.usgs.gov/nwis/site/", params
-        )
-        if text:
-            records = parse_rdb(text)
-            self.log(f"Retrieved {len(records)} records")
-            return records
+        reached_end: bool = False
+        records: list = []
+        sites_url: str = "https://api.waterdata.usgs.gov/ogcapi/v0/collections/monitoring-locations/items"
 
+        """
+        TODO
+
+        update the site transformer to transform into standardized format
+        """
+
+        while not reached_end:
+            response = self._execute_json_request(
+                url=sites_url,
+                params=params,
+                headers={"X-API-Key": KEY}
+            )
+
+            records.extend(response.get("features", []))
+
+            found_next_link: bool = False
+            for link in response["links"]:
+                if link["rel"] == "next":
+                    sites_url = link["href"]
+                    params = None  # next link already has params encoded
+                    found_next_link = True
+                    break
+            
+            if not found_next_link  :
+                reached_end = True
+           
+
+        return records
+
+
+# TODO: IMPLEMENT! and transform as necessary. keep in mind "next" links for pagination
 
 class NWISWaterLevelSource(BaseWaterLevelSource):
     transformer_klass = NWISWaterLevelTransformer
+    # chunk_size=5 to avoid URI length and httpx read timed out issue
+    chunk_size = 5
 
     def __repr__(self):
         return "NWISWaterLevelSource"
 
     def get_records(self, site_record):
-        # query sites with the agency, which need to be in the form of "{agency}:{site number}"
-        sites = make_site_list(site_record)
-        sites_with_colons = [s.replace("-", ":") for s in sites]
+        records: list = []
 
-        params = {
-            "format": "json",
-            "siteType": "GW",
-            "siteStatus": "all",
-            "parameterCd": "72019",
-            "sites": ",".join(sites_with_colons),
-        }
+        # if more than 5 sites are provided the URI is too long
+        sites: list = make_site_list(site_record)
 
-        config = self.config
-        if config.start_date:
-            params["startDt"] = config.start_dt.date().isoformat()
-        else:
-            params["startDt"] = "1900-01-01"
+        # chunk the sites into groups of 5 to avoid URI length issues
+        chunks_of_sites: list = []
+        for i in range(0, len(sites), self.chunk_size):
+            chunks_of_sites.append(sites[i:i + self.chunk_size]) 
 
-        if config.end_date:
-            params["endDt"] = config.end_dt.date().isoformat()
 
-        data = self._execute_json_request(
-            url="https://waterservices.usgs.gov/nwis/gwlevels/",
-            params=params,
-            tag="value",
-        )
-        if data:
-            records = parse_json(data)
-            self.log(f"Retrieved {len(records)} records")
-            return records
+        for chunked_sites in chunks_of_sites:
+            delineated_sites: str = ",".join(chunked_sites)
+        
+            obs_url: str = "https://api.waterdata.usgs.gov/ogcapi/v0/collections/field-measurements/items"
+
+            reached_end: bool = False
+
+            params: dict = {
+                "parameter_code": "72019",
+                "monitoring_location_id": delineated_sites,
+                "limit": 500,
+            }
+
+            config = self.config
+            # if config.start_date:
+            #     params["startDt"] = config.start_dt.date().isoformat()
+            # else:
+            #     params["startDt"] = "1900-01-01"
+
+            # if config.end_date:
+            #     params["endDt"] = config.end_dt.date().isoformat()
+
+            while not reached_end:
+                response = self._execute_json_request(
+                    url=obs_url,
+                    params=params,
+                    headers={"X-API-Key": KEY}
+                )
+
+                data: list[dict] = response.get("features", [])
+                if data:
+                    for feature in data:
+                        record = {
+                            "site_id": feature["properties"]["monitoring_location_id"],
+                            "source_parameter_name": "Water level, depth LSD",
+                            "value": feature["properties"]["value"],
+                            "datetime_measured": feature["properties"]["time"],
+                            "source_parameter_units": feature["properties"]["unit_of_measure"]
+                        }
+                        records.append(record)
+
+                found_next_link: bool = False
+                for link in response["links"]:
+                    if link["rel"] == "next":
+                        obs_url = link["href"]
+                        params = None  # next link already has params encoded
+                        found_next_link = True
+                        break
+                
+                if not found_next_link  :
+                    reached_end = True
+        self.log(f"Retrieved {len(records)} records")
+
+
+        return records
 
     def _extract_site_records(self, records, site_record):
         return [ri for ri in records if ri["site_id"] == site_record.id]

--- a/backend/connectors/usgs/source.py
+++ b/backend/connectors/usgs/source.py
@@ -49,6 +49,7 @@ class NWISSiteSource(BaseSiteSource):
     transformer_klass = NWISSiteTransformer
     chunk_size = 500
     bounding_polygon = NM_STATE_BOUNDING_POLYGON
+    sites_url: str = "https://api.waterdata.usgs.gov/ogcapi/v0/collections/combined-metadata/items"
 
     def __repr__(self):
         return "NWISSiteSource"
@@ -59,12 +60,12 @@ class NWISSiteSource(BaseSiteSource):
 
     def health(self):
         try:
-            httpx.post(
-                url="https://api.waterdata.usgs.gov/ogcapi/v0/collections/combined-metadata/items",
-                data=self.json_data,
-                headers={"X-API-Key": KEY, "Content-Type": "application/query-cql-json"},
-                timeout=None
-            )
+            data = self._execute_json_request(
+            url=self.sites_url,
+            params={"limit": LIMIT, "parameter_code": "72019", "site_type_code": "GW", "state_code": "35"},
+            timeout=None,
+            headers={"X-API-Key": KEY},
+        )
             return True
         except httpx.HTTPStatusError:
             pass
@@ -83,10 +84,9 @@ class NWISSiteSource(BaseSiteSource):
         #     params["startDt"] = config.start_dt.date().isoformat()
         # if config.end_date:
         #     params["endDt"] = config.end_dt.date().isoformat()
-        sites_url: str = "https://api.waterdata.usgs.gov/ogcapi/v0/collections/combined-metadata/items"
 
         data = self._execute_json_request(
-            url=sites_url,
+            url=self.sites_url,
             params={"limit": LIMIT, "parameter_code": "72019", "site_type_code": "GW", "state_code": "35"},
             timeout=None,
             headers={"X-API-Key": KEY},

--- a/backend/connectors/usgs/source.py
+++ b/backend/connectors/usgs/source.py
@@ -71,7 +71,7 @@ class NWISSiteSource(BaseSiteSource):
             )
             response.raise_for_status()
             return True
-        except httpx.HTTPStatusError:
+        except httpx.HTTPError:
             return False
 
     def get_records(self):

--- a/backend/connectors/usgs/source.py
+++ b/backend/connectors/usgs/source.py
@@ -37,9 +37,9 @@ from backend.source import (
 )
 
 
-KEY = "55MILtQrayXw1NgufxcqRfkkRrg4Rg6KNCyJZ004"
+# KEY = "55MILtQrayXw1NgufxcqRfkkRrg4Rg6KNCyJZ004"
 LIMIT = 50000    
-TIMEOUT=1800
+TIMEOUT=15*60  # 15 minutes, to allow for retries and large requests
 
 class NWISSiteSource(BaseSiteSource):
     transformer_klass = NWISSiteTransformer
@@ -60,7 +60,6 @@ class NWISSiteSource(BaseSiteSource):
                 url=self.sites_url,
                 params={"limit": 1, "parameter_code": "72019", "site_type_code": "GW", "state_code": "35"},
                 timeout=TIMEOUT,
-                headers={"X-API-Key": KEY},
             )
             return True
         except httpx.HTTPStatusError:
@@ -88,7 +87,6 @@ class NWISSiteSource(BaseSiteSource):
                     url=self.sites_url,
                     params={"limit": LIMIT, "parameter_code": "72019", "site_type_code": "GW", "state_code": "35"},
                     timeout=TIMEOUT,
-                    headers={"X-API-Key": KEY},
                 )
                 # _execute_json_request returns None for non-200 responses, so we need to check for that as well
                 if data is None:
@@ -147,7 +145,7 @@ class NWISWaterLevelSource(BaseWaterLevelSource):
                     response = httpx.post(
                         url="https://api.waterdata.usgs.gov/ogcapi/v0/collections/field-measurements/items",
                         json=json_data,
-                        headers={"X-API-Key": KEY, "Content-Type": "application/query-cql-json"},
+                        headers={"Content-Type": "application/query-cql-json"},
                         params={"limit": LIMIT, "parameter_code": "72019"},
                         timeout=TIMEOUT,
                     )
@@ -186,7 +184,7 @@ class NWISWaterLevelSource(BaseWaterLevelSource):
                     try:
                         response = httpx.get(
                                 url=next_link_url,
-                                headers={"X-API-Key": KEY, "Content-Type": "application/query-cql-json"},
+                                headers={"Content-Type": "application/query-cql-json"},
                                 timeout=TIMEOUT,
                             )
                         if response.status_code != 200:

--- a/backend/connectors/usgs/source.py
+++ b/backend/connectors/usgs/source.py
@@ -66,7 +66,7 @@ class NWISSiteSource(BaseSiteSource):
             response = httpx.get(
                 url=self.sites_url,
                 params={"limit": 1, "parameter_code": "72019", "site_type_code": "GW", "state_code": "35"},
-                timeout=TIMEOUT,
+                timeout=30,
                 headers=headers
             )
             response.raise_for_status()

--- a/backend/connectors/usgs/source.py
+++ b/backend/connectors/usgs/source.py
@@ -77,7 +77,6 @@ class NWISSiteSource(BaseSiteSource):
     def get_records(self):
         params: dict = {
             "limit": LIMIT,
-            "parameter_code": "72019",
             "site_type_code": "GW",
         }
 
@@ -95,6 +94,9 @@ class NWISSiteSource(BaseSiteSource):
             end: str = self.config.end_dt.date().isoformat()
             end = f"{end}T23:59:59Z"
             params["end"] = end
+
+        if not self.config.sites_only:
+            params["parameter_code"] = "72019"
 
         data: dict = {}
         tries: int = 0

--- a/backend/connectors/usgs/source.py
+++ b/backend/connectors/usgs/source.py
@@ -259,67 +259,6 @@ class NWISWaterLevelSource(BaseWaterLevelSource):
 
             standard_features: list[dict] = [self._standardize_record(feature) for feature in features]
             records.extend(standard_features)
-            
-            """
-            The following commented-out code handles pagination for cases where there are more than LIMIT records for a given batch of sites.
-            However, in testing, I have not encountered any cases where this is necessary. Furthermore, cursor-based pagination is broken as
-            of 4/29/26 when the limit query parameter is used, and it can't be used in combination with other parameters via complex queries.
-            If we do encounter cases where there are more than LIMIT records, we can use the following code to handle pagination (when it is fixed).
-            
-            found_next_link: bool = False
-            links: list[dict] = data.get("links", [])
-            for link in links:
-                if link["rel"] == "next":
-                    next_link_url = link["href"]
-                    found_next_link = True
-                    break
-
-            # use GET requests for the paginated responses after the initial POST to avoid issues with httpx and long URLs with many site ids
-            # USGS APIs use cursor pagination, so we can just follow the "next" links until there are no more
-            while found_next_link:
-                tries: int = 0
-                data: dict = {}
-                while tries < MAX_RETRIES:
-                    try:
-                        response = httpx.get(
-                                url=next_link_url,
-                                headers=headers,
-                                timeout=TIMEOUT,
-                            )
-                        if response.status_code == 200:
-                            data = response.json()
-                            break
-                        elif response.status_code == 429:
-                            raise USGSRateLimitError()
-                        else:
-                            self.warn(f"Received status code {response.status_code} for paginated request. Retrying... {tries + 1}/{MAX_RETRIES}")
-                    except USGSRateLimitError:
-                        self.warn("Rate limit exceeded. Please provide a valid USGS API key via the --usgs-api-key flag to increase your rate limit and try again.")
-                        raise USGSRateLimitError("Rate limit exceeded")
-                    except json.JSONDecodeError as e:
-                        self.warn(f"Failed to decode JSON response: {e}. Retrying... {tries + 1}/{MAX_RETRIES}")
-                    except Exception as e:
-                        self.warn(f"Error retrieving paginated water level records: {e}. Retrying... {tries + 1}/{MAX_RETRIES}")
-                    
-                    tries += 1
-                    time.sleep(tries)
-                
-                if data == {}:
-                    self.warn("Failed to retrieve paginated water level records after multiple attempts.")
-                    raise PartialOrNoDataError("Failed to retrieve paginated water level records after multiple attempts")
-
-                features: list[dict] = data.get("features", [])
-                standard_features: list[dict] = [self._standardize_record(feature) for feature in features]
-                records.extend(standard_features)
-                
-                found_next_link: bool = False
-                links: list = data.get("links", [])
-                for link in links:
-                    if link["rel"] == "next":
-                        next_link_url = link["href"]
-                        found_next_link = True
-                        break
-            """
 
         self.log(f"Retrieved {len(records)} records")
 

--- a/backend/connectors/usgs/source.py
+++ b/backend/connectors/usgs/source.py
@@ -15,6 +15,7 @@
 # ===============================================================================
 import httpx
 import os
+import sys
 
 from backend.connectors import NM_STATE_BOUNDING_POLYGON
 from backend.constants import (
@@ -91,13 +92,21 @@ class NWISSiteSource(BaseSiteSource):
                     headers = {"X-API-Key": os.environ["USGS_API_KEY"]}
                 else:
                     headers = {}
-                data = self._execute_json_request(
+                response = httpx.get(
                     url=self.sites_url,
                     params={"limit": LIMIT, "parameter_code": "72019", "site_type_code": "GW", "state_code": "35"},
                     timeout=TIMEOUT,
                     headers=headers
                 )
-                # _execute_json_request returns None for non-200 responses, so we need to check for that as well
+
+                if response.status_code == 429:
+                    self.warn("Rate limit exceeded. Please provide a valid USGS API key via the --usgs-api-key flag to increase your rate limit and try again.")
+                    sys.exit(1)
+                elif response.status_code != 200:
+                    self.warn(f"Received status code {response.status_code}. Retrying...")
+                    continue
+                else:
+                    data = response.json()
                 if data is None:
                     self.warn("Retrying...")
                 else:
@@ -162,7 +171,10 @@ class NWISWaterLevelSource(BaseWaterLevelSource):
                         params={"limit": LIMIT, "parameter_code": "72019"},
                         timeout=TIMEOUT,
                     )
-                    if response.status_code != 200:
+                    if response.status_code == 429:
+                        self.warn("Rate limit exceeded. Please provide a valid USGS API key via the --usgs-api-key flag to increase your rate limit and try again.")
+                        sys.exit(1)
+                    elif response.status_code != 200:
                         self.warn(f"Received status code {response.status_code}. Retrying...")
                     else:
                         finished_request = True

--- a/backend/connectors/usgs/source.py
+++ b/backend/connectors/usgs/source.py
@@ -15,6 +15,7 @@
 # ===============================================================================
 import httpx
 import os
+import time
 
 from backend.connectors import NM_STATE_BOUNDING_POLYGON
 from backend.constants import (
@@ -39,7 +40,7 @@ from backend.source import (
 
 LIMIT = 50000    
 TIMEOUT=15*60  # 15 minutes, to allow for retries and large requests
-
+MAX_RETRIES = 7
 
 class USGSRateLimitError(Exception):
     pass
@@ -88,8 +89,9 @@ class NWISSiteSource(BaseSiteSource):
         # if config.end_date:
         #     params["endDt"] = config.end_dt.date().isoformat()
 
-        finished_request: bool = False
-        while not finished_request:
+        tries: int = 0
+
+        while tries < MAX_RETRIES:
             try:
                 if os.environ.get("USGS_API_KEY") is not None:
                     headers = {"X-API-Key": os.environ["USGS_API_KEY"]}
@@ -102,23 +104,23 @@ class NWISSiteSource(BaseSiteSource):
                     headers=headers
                 )
 
-                if response.status_code == 429:
+                if response.status_code == 200:
+                    break
+                elif response.status_code == 429:
                     raise USGSRateLimitError()
-                elif response.status_code != 200:
-                    self.warn(f"Received status code {response.status_code}. Retrying...")
-                    continue
                 else:
-                    data = response.json()
-                if data is None:
-                    self.warn("Retrying...")
-                else:
-                    finished_request = True
+                    self.warn(f"Received status code {response.status_code}. Retrying... {tries + 1}/{MAX_RETRIES}")
+
             except USGSRateLimitError:
                 self.warn("Rate limit exceeded. Please provide a valid USGS API key via the --usgs-api-key flag to increase your rate limit and try again.")
                 raise USGSRateLimitError("Rate limit exceeded")
             except Exception as e:
-                self.warn(f"Error retrieving site records: {e}. Retrying...")
+                self.warn(f"Error retrieving site records: {e}. Retrying... {tries + 1}/{MAX_RETRIES}")
+            
+            tries += 1
+            time.sleep(tries)
 
+        data: dict = response.json()
         records: list = data.get("features", [])
 
         return records
@@ -162,8 +164,9 @@ class NWISWaterLevelSource(BaseWaterLevelSource):
                     list_of_sites
                 ]
             }
-            finished_request: bool = False
-            while not finished_request:
+            tries: int = 0
+
+            while tries < MAX_RETRIES:
                 try:
                     if os.environ.get("USGS_API_KEY") is not None:
                         headers = {"X-API-Key": os.environ["USGS_API_KEY"], "Content-Type": "application/query-cql-json"}
@@ -176,17 +179,21 @@ class NWISWaterLevelSource(BaseWaterLevelSource):
                         params={"limit": LIMIT, "parameter_code": "72019"},
                         timeout=TIMEOUT,
                     )
-                    if response.status_code == 429:
-                        raise USGSRateLimitError("Rate limit exceeded")
-                    elif response.status_code != 200:
-                        self.warn(f"Received status code {response.status_code}. Retrying...")
+                    if response.status_code == 200:
+                        break
+                    elif response.status_code == 429:
+                        raise USGSRateLimitError()
                     else:
-                        finished_request = True
+                        self.warn(f"Received status code {response.status_code}. Retrying... {tries + 1}/{MAX_RETRIES}")
+
                 except USGSRateLimitError:
                     self.warn("Rate limit exceeded. Please provide a valid USGS API key via the --usgs-api-key flag to increase your rate limit and try again.")
                     raise USGSRateLimitError("Rate limit exceeded")
                 except Exception as e:
-                    self.warn(f"Error retrieving water level records: {e}. Retrying...")
+                    self.warn(f"Error retrieving water level records: {e}. Retrying... {tries + 1}/{MAX_RETRIES}")
+                
+                tries += 1
+                time.sleep(tries)
 
             data: dict = response.json()
             features: list[dict] = data.get("features", [])
@@ -211,21 +218,29 @@ class NWISWaterLevelSource(BaseWaterLevelSource):
             # use GET requests for the paginated responses after the initial POST to avoid issues with httpx and long URLs with many site ids
             # USGS APIs use cursor pagination, so we can just follow the "next" links until there are no more
             while found_next_link:
-                finished_request: bool = False
-                while not finished_request:
+                tries: int = 0
+                while tries < MAX_RETRIES:
                     try:
                         response = httpx.get(
                                 url=next_link_url,
                                 headers=headers,
                                 timeout=TIMEOUT,
                             )
-                        if response.status_code != 200:
-                            self.warn(f"Received status code {response.status_code} for paginated request. Retrying...")
+                        if response.status_code == 200:
+                            break
+                        elif response.status_code == 429:
+                            raise USGSRateLimitError()
                         else:
-                            finished_request = True
+                            self.warn(f"Received status code {response.status_code} for paginated request. Retrying... {tries + 1}/{MAX_RETRIES}")
+                    except USGSRateLimitError:
+                        self.warn("Rate limit exceeded. Please provide a valid USGS API key via the --usgs-api-key flag to increase your rate limit and try again.")
+                        raise USGSRateLimitError("Rate limit exceeded")
                     except Exception as e:
-                        self.warn(f"Error retrieving paginated water level records: {e}. Retrying...
-                        
+                        self.warn(f"Error retrieving paginated water level records: {e}. Retrying... {tries + 1}/{MAX_RETRIES}")
+                    
+                    tries += 1
+                    time.sleep(tries)
+                
                 data: dict = response.json()
                 features: list[dict] = data.get("features", [])
                 standard_features: list[dict] = [self._standardize_record(feature) for feature in features]

--- a/backend/connectors/usgs/source.py
+++ b/backend/connectors/usgs/source.py
@@ -137,6 +137,16 @@ class NWISSiteSource(BaseSiteSource):
 
         records: list = data.get("features", [])
 
+        links: list[dict] = data.get("links", [])
+        has_next_link: bool = any(link.get("rel") == "next" for link in links)
+        if has_next_link:
+            self.warn(
+                "USGS water-level response indicates additional pages of data are available, but pagination is not currently supported for this query. Refusing to return a silently truncated dataset."
+            )
+            raise PartialOrNoDataError(
+                "USGS water-level response was truncated; additional pages are available."
+            )
+
         return records
 
 
@@ -231,6 +241,15 @@ class NWISWaterLevelSource(BaseWaterLevelSource):
                 raise PartialOrNoDataError("Failed to retrieve water level records after multiple attempts.")
 
             features: list[dict] = data.get("features", [])
+            links: list[dict] = data.get("links", [])
+            has_next_link: bool = any(link.get("rel") == "next" for link in links)
+            if has_next_link:
+                self.warn(
+                    "USGS water-level response indicates additional pages of data are available, but pagination is not currently supported for this query. Refusing to return a silently truncated dataset."
+                )
+                raise PartialOrNoDataError(
+                    "USGS water-level response was truncated; additional pages are available."
+                )
 
             standard_features: list[dict] = [self._standardize_record(feature) for feature in features]
             records.extend(standard_features)

--- a/backend/connectors/usgs/source.py
+++ b/backend/connectors/usgs/source.py
@@ -325,7 +325,7 @@ class NWISWaterLevelSource(BaseWaterLevelSource):
         return {
             "site_id": record["properties"]["monitoring_location_id"],
             "source_parameter_name": "Water level, depth LSD",
-            "value": record["properties"]["value"],
+            "value": None if record["properties"]["value"] is None else str(record["properties"]["value"]),
             "datetime_measured": record["properties"]["time"],
             "source_parameter_units": record["properties"]["unit_of_measure"]
         }

--- a/backend/connectors/usgs/source.py
+++ b/backend/connectors/usgs/source.py
@@ -69,10 +69,8 @@ class NWISSiteSource(BaseSiteSource):
                 timeout=TIMEOUT,
                 headers=headers
             )
-            if response.status_code == 200:
-                return True
-            else:
-                return False
+            response.raise_for_status()
+            return True
         except httpx.HTTPStatusError:
             return False
 

--- a/backend/connectors/usgs/source.py
+++ b/backend/connectors/usgs/source.py
@@ -15,7 +15,6 @@
 # ===============================================================================
 import httpx
 import os
-import sys
 
 from backend.connectors import NM_STATE_BOUNDING_POLYGON
 from backend.constants import (
@@ -40,6 +39,10 @@ from backend.source import (
 
 LIMIT = 50000    
 TIMEOUT=15*60  # 15 minutes, to allow for retries and large requests
+
+
+class USGSRateLimitError(Exception):
+    pass
 
 class NWISSiteSource(BaseSiteSource):
     transformer_klass = NWISSiteTransformer
@@ -100,8 +103,7 @@ class NWISSiteSource(BaseSiteSource):
                 )
 
                 if response.status_code == 429:
-                    self.warn("Rate limit exceeded. Please provide a valid USGS API key via the --usgs-api-key flag to increase your rate limit and try again.")
-                    sys.exit(1)
+                    raise USGSRateLimitError()
                 elif response.status_code != 200:
                     self.warn(f"Received status code {response.status_code}. Retrying...")
                     continue
@@ -111,6 +113,9 @@ class NWISSiteSource(BaseSiteSource):
                     self.warn("Retrying...")
                 else:
                     finished_request = True
+            except USGSRateLimitError:
+                self.warn("Rate limit exceeded. Please provide a valid USGS API key via the --usgs-api-key flag to increase your rate limit and try again.")
+                raise USGSRateLimitError("Rate limit exceeded")
             except Exception as e:
                 self.warn(f"Error retrieving site records: {e}. Retrying...")
 
@@ -172,12 +177,14 @@ class NWISWaterLevelSource(BaseWaterLevelSource):
                         timeout=TIMEOUT,
                     )
                     if response.status_code == 429:
-                        self.warn("Rate limit exceeded. Please provide a valid USGS API key via the --usgs-api-key flag to increase your rate limit and try again.")
-                        sys.exit(1)
+                        raise USGSRateLimitError("Rate limit exceeded")
                     elif response.status_code != 200:
                         self.warn(f"Received status code {response.status_code}. Retrying...")
                     else:
                         finished_request = True
+                except USGSRateLimitError:
+                    self.warn("Rate limit exceeded. Please provide a valid USGS API key via the --usgs-api-key flag to increase your rate limit and try again.")
+                    raise USGSRateLimitError("Rate limit exceeded")
                 except Exception as e:
                     self.warn(f"Error retrieving water level records: {e}. Retrying...")
 

--- a/backend/connectors/usgs/source.py
+++ b/backend/connectors/usgs/source.py
@@ -31,6 +31,7 @@ from backend.connectors.usgs.transformer import (
     NWISSiteTransformer,
     NWISWaterLevelTransformer,
 )
+from backend.exceptions import USGSRateLimitError
 from backend.source import (
     BaseWaterLevelSource,
     BaseSiteSource,
@@ -41,9 +42,6 @@ from backend.source import (
 LIMIT = 50000    
 TIMEOUT=15*60  # 15 minutes, to allow for retries and large requests
 MAX_RETRIES = 7
-
-class USGSRateLimitError(Exception):
-    pass
 
 class NWISSiteSource(BaseSiteSource):
     transformer_klass = NWISSiteTransformer

--- a/backend/connectors/usgs/source.py
+++ b/backend/connectors/usgs/source.py
@@ -77,14 +77,14 @@ class NWISSiteSource(BaseSiteSource):
             return False
 
     def get_records(self):
-        params = {
+        params: dict = {
             "limit": LIMIT,
             "parameter_code": "72019",
             "site_type_code": "GW",
         }
 
         if self.config.has_bounds():
-            bbox = self.config.bbox_bounding_points()
+            bbox: tuple = self.config.bbox_bounding_points()
             params["bbox"] = ",".join([str(b) for b in bbox])
         else:
             params["state_code"] = "35"
@@ -152,7 +152,7 @@ class NWISWaterLevelSource(BaseWaterLevelSource):
         return "NWISWaterLevelSource"
 
     def get_records(self, site_record):
-        params = {
+        params: dict = {
             "limit": LIMIT,
             "parameter_code": "72019",
         }
@@ -161,10 +161,10 @@ class NWISWaterLevelSource(BaseWaterLevelSource):
         end: str = ""
 
         if self.config.start_date:
-            begin: str = self.config.start_dt.date().isoformat()
+            begin = self.config.start_dt.date().isoformat()
             begin = f"{begin}T00:00:00Z"
         if self.config.end_date:
-            end: str = self.config.end_dt.date().isoformat()
+            end = self.config.end_dt.date().isoformat()
             end = f"{end}T23:59:59Z"
 
         if begin and end:

--- a/backend/connectors/usgs/source.py
+++ b/backend/connectors/usgs/source.py
@@ -77,19 +77,26 @@ class NWISSiteSource(BaseSiteSource):
             return False
 
     def get_records(self):
-        # TODO: handle date filters
-        # config = self.config
+        params = {
+            "limit": LIMIT,
+            "parameter_code": "72019",
+            "site_type_code": "GW",
+        }
 
-        # if config.has_bounds():
-        #     bbox = config.bbox_bounding_points()
-        #     params["bbox"] = ",".join([str(b) for b in bbox])
-        # else:
-        #     params["state_code"] = "35"
+        if self.config.has_bounds():
+            bbox = self.config.bbox_bounding_points()
+            params["bbox"] = ",".join([str(b) for b in bbox])
+        else:
+            params["state_code"] = "35"
 
-        # if config.start_date:
-        #     params["startDt"] = config.start_dt.date().isoformat()
-        # if config.end_date:
-        #     params["endDt"] = config.end_dt.date().isoformat()
+        if self.config.start_date:
+            begin: str = self.config.start_dt.date().isoformat()
+            begin = f"{begin}T00:00:00Z"
+            params["begin"] = begin
+        if self.config.end_date:
+            end: str = self.config.end_dt.date().isoformat()
+            end = f"{end}T23:59:59Z"
+            params["end"] = end
 
         data: dict = {}
         tries: int = 0
@@ -102,7 +109,7 @@ class NWISSiteSource(BaseSiteSource):
                     headers = {}
                 response = httpx.get(
                     url=self.sites_url,
-                    params={"limit": LIMIT, "parameter_code": "72019", "site_type_code": "GW", "state_code": "35"},
+                    params=params,
                     timeout=TIMEOUT,
                     headers=headers
                 )
@@ -145,15 +152,27 @@ class NWISWaterLevelSource(BaseWaterLevelSource):
         return "NWISWaterLevelSource"
 
     def get_records(self, site_record):
-        # TODO: handle date filters
-        # config = self.config
-        # if config.start_date:
-        #     params["startDt"] = config.start_dt.date().isoformat()
-        # else:
-        #     params["startDt"] = "1900-01-01"
+        params = {
+            "limit": LIMIT,
+            "parameter_code": "72019",
+        }
 
-        # if config.end_date:
-        #     params["endDt"] = config.end_dt.date().isoformat()
+        begin: str = ""
+        end: str = ""
+
+        if self.config.start_date:
+            begin: str = self.config.start_dt.date().isoformat()
+            begin = f"{begin}T00:00:00Z"
+        if self.config.end_date:
+            end: str = self.config.end_dt.date().isoformat()
+            end = f"{end}T23:59:59Z"
+
+        if begin and end:
+            params["datetime"] = f"{begin}/{end}"
+        elif begin:
+            params["datetime"] = f"{begin}/.."
+        elif end:
+            params["datetime"] = f"../{end}"
 
         records: list = []
         sites: list = make_site_list(site_record)
@@ -187,7 +206,7 @@ class NWISWaterLevelSource(BaseWaterLevelSource):
                         url="https://api.waterdata.usgs.gov/ogcapi/v0/collections/field-measurements/items",
                         json=json_data,
                         headers=headers,
-                        params={"limit": LIMIT, "parameter_code": "72019"},
+                        params=params,
                         timeout=TIMEOUT,
                     )
                     if response.status_code == 200:
@@ -264,7 +283,7 @@ class NWISWaterLevelSource(BaseWaterLevelSource):
                 
                 if data == {}:
                     self.warn("Failed to retrieve paginated water level records after multiple attempts.")
-                    raise PartialOrNoDataError("Failed to retrieve paginated water level records after multiple attempts
+                    raise PartialOrNoDataError("Failed to retrieve paginated water level records after multiple attempts")
 
                 features: list[dict] = data.get("features", [])
                 standard_features: list[dict] = [self._standardize_record(feature) for feature in features]

--- a/backend/connectors/usgs/source.py
+++ b/backend/connectors/usgs/source.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 # ===============================================================================
 import httpx
+import os
 
 from backend.connectors import NM_STATE_BOUNDING_POLYGON
 from backend.constants import (
@@ -36,8 +37,6 @@ from backend.source import (
     get_terminal_record,
 )
 
-
-# KEY = "55MILtQrayXw1NgufxcqRfkkRrg4Rg6KNCyJZ004"
 LIMIT = 50000    
 TIMEOUT=15*60  # 15 minutes, to allow for retries and large requests
 
@@ -56,10 +55,15 @@ class NWISSiteSource(BaseSiteSource):
 
     def health(self):
         try:
+            if os.environ.get("USGS_API_KEY") is not None:
+                headers = {"X-API-Key": os.environ["USGS_API_KEY"]}
+            else:
+                headers = {}
             self._execute_json_request(
                 url=self.sites_url,
                 params={"limit": 1, "parameter_code": "72019", "site_type_code": "GW", "state_code": "35"},
                 timeout=TIMEOUT,
+                headers=headers
             )
             return True
         except httpx.HTTPStatusError:
@@ -83,10 +87,15 @@ class NWISSiteSource(BaseSiteSource):
         finished_request: bool = False
         while not finished_request:
             try:
+                if os.environ.get("USGS_API_KEY") is not None:
+                    headers = {"X-API-Key": os.environ["USGS_API_KEY"]}
+                else:
+                    headers = {}
                 data = self._execute_json_request(
                     url=self.sites_url,
                     params={"limit": LIMIT, "parameter_code": "72019", "site_type_code": "GW", "state_code": "35"},
                     timeout=TIMEOUT,
+                    headers=headers
                 )
                 # _execute_json_request returns None for non-200 responses, so we need to check for that as well
                 if data is None:
@@ -142,10 +151,14 @@ class NWISWaterLevelSource(BaseWaterLevelSource):
             finished_request: bool = False
             while not finished_request:
                 try:
+                    if os.environ.get("USGS_API_KEY") is not None:
+                        headers = {"X-API-Key": os.environ["USGS_API_KEY"], "Content-Type": "application/query-cql-json"}
+                    else:
+                        headers = {"Content-Type": "application/query-cql-json"}
                     response = httpx.post(
                         url="https://api.waterdata.usgs.gov/ogcapi/v0/collections/field-measurements/items",
                         json=json_data,
-                        headers={"Content-Type": "application/query-cql-json"},
+                        headers=headers,
                         params={"limit": LIMIT, "parameter_code": "72019"},
                         timeout=TIMEOUT,
                     )
@@ -184,7 +197,7 @@ class NWISWaterLevelSource(BaseWaterLevelSource):
                     try:
                         response = httpx.get(
                                 url=next_link_url,
-                                headers={"Content-Type": "application/query-cql-json"},
+                                headers=headers,
                                 timeout=TIMEOUT,
                             )
                         if response.status_code != 200:

--- a/backend/connectors/usgs/source.py
+++ b/backend/connectors/usgs/source.py
@@ -16,6 +16,7 @@
 import httpx
 import os
 import time
+import json
 
 from backend.connectors import NM_STATE_BOUNDING_POLYGON
 from backend.constants import (
@@ -103,6 +104,7 @@ class NWISSiteSource(BaseSiteSource):
                 )
 
                 if response.status_code == 200:
+                    data: dict = response.json()
                     break
                 elif response.status_code == 429:
                     raise USGSRateLimitError()
@@ -112,13 +114,14 @@ class NWISSiteSource(BaseSiteSource):
             except USGSRateLimitError:
                 self.warn("Rate limit exceeded. Please provide a valid USGS API key via the --usgs-api-key flag to increase your rate limit and try again.")
                 raise USGSRateLimitError("Rate limit exceeded")
+            except json.JSONDecodeError as e:
+                self.warn(f"Failed to decode JSON response: {e}. Retrying... {tries + 1}/{MAX_RETRIES}")
             except Exception as e:
                 self.warn(f"Error retrieving site records: {e}. Retrying... {tries + 1}/{MAX_RETRIES}")
             
             tries += 1
             time.sleep(tries)
 
-        data: dict = response.json()
         records: list = data.get("features", [])
 
         return records
@@ -178,6 +181,7 @@ class NWISWaterLevelSource(BaseWaterLevelSource):
                         timeout=TIMEOUT,
                     )
                     if response.status_code == 200:
+                        data: dict = response.json()
                         break
                     elif response.status_code == 429:
                         raise USGSRateLimitError()
@@ -187,13 +191,14 @@ class NWISWaterLevelSource(BaseWaterLevelSource):
                 except USGSRateLimitError:
                     self.warn("Rate limit exceeded. Please provide a valid USGS API key via the --usgs-api-key flag to increase your rate limit and try again.")
                     raise USGSRateLimitError("Rate limit exceeded")
+                except json.JSONDecodeError as e:
+                    self.warn(f"Failed to decode JSON response: {e}. Retrying... {tries + 1}/{MAX_RETRIES}")
                 except Exception as e:
                     self.warn(f"Error retrieving water level records: {e}. Retrying... {tries + 1}/{MAX_RETRIES}")
                 
                 tries += 1
                 time.sleep(tries)
 
-            data: dict = response.json()
             features: list[dict] = data.get("features", [])
 
             standard_features: list[dict] = [self._standardize_record(feature) for feature in features]
@@ -225,6 +230,7 @@ class NWISWaterLevelSource(BaseWaterLevelSource):
                                 timeout=TIMEOUT,
                             )
                         if response.status_code == 200:
+                            data: dict = response.json()
                             break
                         elif response.status_code == 429:
                             raise USGSRateLimitError()
@@ -233,13 +239,14 @@ class NWISWaterLevelSource(BaseWaterLevelSource):
                     except USGSRateLimitError:
                         self.warn("Rate limit exceeded. Please provide a valid USGS API key via the --usgs-api-key flag to increase your rate limit and try again.")
                         raise USGSRateLimitError("Rate limit exceeded")
+                    except json.JSONDecodeError as e:
+                        self.warn(f"Failed to decode JSON response: {e}. Retrying... {tries + 1}/{MAX_RETRIES}")
                     except Exception as e:
                         self.warn(f"Error retrieving paginated water level records: {e}. Retrying... {tries + 1}/{MAX_RETRIES}")
                     
                     tries += 1
                     time.sleep(tries)
                 
-                data: dict = response.json()
                 features: list[dict] = data.get("features", [])
                 standard_features: list[dict] = [self._standardize_record(feature) for feature in features]
                 records.extend(standard_features)

--- a/backend/connectors/usgs/source.py
+++ b/backend/connectors/usgs/source.py
@@ -187,7 +187,7 @@ class NWISWaterLevelSource(BaseWaterLevelSource):
         records: list = []
         sites: list = make_site_list(site_record)
 
-        # if make_site_list returns a site site id as a string, convert to list for consistency with the batch processing logic below
+        # if make_site_list returns a site id as a string, convert to list for consistency with the batch processing logic below
         if isinstance(sites, str):
             sites = [sites]
 

--- a/backend/connectors/usgs/source.py
+++ b/backend/connectors/usgs/source.py
@@ -59,7 +59,7 @@ class NWISSiteSource(BaseSiteSource):
 
     def health(self):
         try:
-            if os.environ.get("USGS_API_KEY") is not None:
+            if os.environ.get("USGS_API_KEY"):
                 headers = {"X-API-Key": os.environ["USGS_API_KEY"]}
             else:
                 headers = {}
@@ -103,7 +103,7 @@ class NWISSiteSource(BaseSiteSource):
 
         while tries < MAX_RETRIES:
             try:
-                if os.environ.get("USGS_API_KEY") is not None:
+                if os.environ.get("USGS_API_KEY"):
                     headers = {"X-API-Key": os.environ["USGS_API_KEY"]}
                 else:
                     headers = {}
@@ -198,7 +198,7 @@ class NWISWaterLevelSource(BaseWaterLevelSource):
 
             while tries < MAX_RETRIES:
                 try:
-                    if os.environ.get("USGS_API_KEY") is not None:
+                    if os.environ.get("USGS_API_KEY"):
                         headers = {"X-API-Key": os.environ["USGS_API_KEY"], "Content-Type": "application/query-cql-json"}
                     else:
                         headers = {"Content-Type": "application/query-cql-json"}

--- a/backend/connectors/usgs/source.py
+++ b/backend/connectors/usgs/source.py
@@ -32,7 +32,7 @@ from backend.connectors.usgs.transformer import (
     NWISSiteTransformer,
     NWISWaterLevelTransformer,
 )
-from backend.exceptions import USGSRateLimitError
+from backend.exceptions import USGSRateLimitError, PartialOrNoDataError
 from backend.source import (
     BaseWaterLevelSource,
     BaseSiteSource,
@@ -91,6 +91,7 @@ class NWISSiteSource(BaseSiteSource):
         # if config.end_date:
         #     params["endDt"] = config.end_dt.date().isoformat()
 
+        data: dict = {}
         tries: int = 0
 
         while tries < MAX_RETRIES:
@@ -107,7 +108,7 @@ class NWISSiteSource(BaseSiteSource):
                 )
 
                 if response.status_code == 200:
-                    data: dict = response.json()
+                    data = response.json()
                     break
                 elif response.status_code == 429:
                     raise USGSRateLimitError()
@@ -124,6 +125,10 @@ class NWISSiteSource(BaseSiteSource):
             
             tries += 1
             time.sleep(tries)
+
+        if data == {}:
+            self.warn("Failed to retrieve site records after multiple attempts.")
+            raise PartialOrNoDataError("Failed to retrieve site records after multiple attempts.")
 
         records: list = data.get("features", [])
 
@@ -168,6 +173,8 @@ class NWISWaterLevelSource(BaseWaterLevelSource):
                     list_of_sites
                 ]
             }
+
+            data: dict = {}
             tries: int = 0
 
             while tries < MAX_RETRIES:
@@ -184,7 +191,7 @@ class NWISWaterLevelSource(BaseWaterLevelSource):
                         timeout=TIMEOUT,
                     )
                     if response.status_code == 200:
-                        data: dict = response.json()
+                        data = response.json()
                         break
                     elif response.status_code == 429:
                         raise USGSRateLimitError()
@@ -201,6 +208,10 @@ class NWISWaterLevelSource(BaseWaterLevelSource):
                 
                 tries += 1
                 time.sleep(tries)
+
+            if data == {}:
+                self.warn("Failed to retrieve water level records after multiple attempts.")
+                raise PartialOrNoDataError("Failed to retrieve water level records after multiple attempts.")
 
             features: list[dict] = data.get("features", [])
 
@@ -225,6 +236,7 @@ class NWISWaterLevelSource(BaseWaterLevelSource):
             # USGS APIs use cursor pagination, so we can just follow the "next" links until there are no more
             while found_next_link:
                 tries: int = 0
+                data: dict = {}
                 while tries < MAX_RETRIES:
                     try:
                         response = httpx.get(
@@ -233,7 +245,7 @@ class NWISWaterLevelSource(BaseWaterLevelSource):
                                 timeout=TIMEOUT,
                             )
                         if response.status_code == 200:
-                            data: dict = response.json()
+                            data = response.json()
                             break
                         elif response.status_code == 429:
                             raise USGSRateLimitError()
@@ -250,6 +262,10 @@ class NWISWaterLevelSource(BaseWaterLevelSource):
                     tries += 1
                     time.sleep(tries)
                 
+                if data == {}:
+                    self.warn("Failed to retrieve paginated water level records after multiple attempts.")
+                    raise PartialOrNoDataError("Failed to retrieve paginated water level records after multiple attempts
+
                 features: list[dict] = data.get("features", [])
                 standard_features: list[dict] = [self._standardize_record(feature) for feature in features]
                 records.extend(standard_features)

--- a/backend/connectors/usgs/source.py
+++ b/backend/connectors/usgs/source.py
@@ -63,13 +63,16 @@ class NWISSiteSource(BaseSiteSource):
                 headers = {"X-API-Key": os.environ["USGS_API_KEY"]}
             else:
                 headers = {}
-            self._execute_json_request(
+            response = httpx.get(
                 url=self.sites_url,
                 params={"limit": 1, "parameter_code": "72019", "site_type_code": "GW", "state_code": "35"},
                 timeout=TIMEOUT,
                 headers=headers
             )
-            return True
+            if response.status_code == 200:
+                return True
+            else:
+                return False
         except httpx.HTTPStatusError:
             return False
 

--- a/backend/connectors/usgs/source.py
+++ b/backend/connectors/usgs/source.py
@@ -187,6 +187,10 @@ class NWISWaterLevelSource(BaseWaterLevelSource):
         records: list = []
         sites: list = make_site_list(site_record)
 
+        # if make_site_list returns a site site id as a string, convert to list for consistency with the batch processing logic below
+        if isinstance(sites, str):
+            sites = [sites]
+
         # group sites into batches of num_sites to pass to the API
         # USGS APIs allow up to 250 sites to be queried at once with complex queries
         list_of_lists_of_sites: list = []

--- a/backend/connectors/usgs/source.py
+++ b/backend/connectors/usgs/source.py
@@ -141,10 +141,10 @@ class NWISSiteSource(BaseSiteSource):
         has_next_link: bool = any(link.get("rel") == "next" for link in links)
         if has_next_link:
             self.warn(
-                "USGS water-level response indicates additional pages of data are available, but pagination is not currently supported for this query. Refusing to return a silently truncated dataset."
+                "USGS site response indicates additional pages of data are available, but pagination is not currently supported for this query. Refusing to return a silently truncated dataset."
             )
             raise PartialOrNoDataError(
-                "USGS water-level response was truncated; additional pages are available."
+                "USGS site response was truncated; additional pages are available."
             )
 
         return records

--- a/backend/connectors/usgs/transformer.py
+++ b/backend/connectors/usgs/transformer.py
@@ -36,7 +36,7 @@ class NWISSiteTransformer(SiteTransformer):
             "longitude": record["geometry"]["coordinates"][0],
             "elevation": elevation,
             "elevation_units": "ft",
-            "horizontal_datum": "WGS84",
+            "horizontal_datum": datum,
             "vertical_datum": record["properties"]["vertical_datum"],
             "aquifer": record["properties"]["national_aquifer_code"],
             "well_depth": record["properties"]["well_constructed_depth"],

--- a/backend/connectors/usgs/transformer.py
+++ b/backend/connectors/usgs/transformer.py
@@ -30,7 +30,7 @@ class NWISSiteTransformer(SiteTransformer):
 
         rec = {
             "source": "USGS",
-            "id": record["properties"]["id"],
+            "id": record["properties"]["monitoring_location_id"],
             "name": record["properties"]["monitoring_location_name"],
             "latitude": record["geometry"]["coordinates"][1],
             "longitude": record["geometry"]["coordinates"][0],

--- a/backend/connectors/usgs/transformer.py
+++ b/backend/connectors/usgs/transformer.py
@@ -19,35 +19,27 @@ from backend.transformer import BaseTransformer, WaterLevelTransformer, SiteTran
 
 class NWISSiteTransformer(SiteTransformer):
     def _transform(self, record):
-        elevation = record["alt_va"]
+        elevation = record["properties"]["altitude"]
         try:
             elevation = float(elevation)
         except (ValueError, TypeError):
             elevation = None
 
-        lng = record["dec_long_va"]
-        lat = record["dec_lat_va"]
-        datum = record["coord_datum_cd"]
-
-        # if not self.contained(lng, lat):
-        #     return
-
-        agency = record["agency_cd"]
-        site_no = record["site_no"]
-        site_id = f"{agency}-{site_no}"
+        # this data comes from OGC API, which requires the use of WGS84 for the horizontal datum
+        datum = "WGS84"
 
         rec = {
-            "source": "USGS-NWIS",
-            "id": site_id,
-            "name": record["station_nm"],
-            "latitude": lat,
-            "longitude": lng,
+            "source": "USGS",
+            "id": record["properties"]["id"],
+            "name": record["properties"]["monitoring_location_name"],
+            "latitude": record["geometry"]["coordinates"][1],
+            "longitude": record["geometry"]["coordinates"][0],
             "elevation": elevation,
             "elevation_units": "ft",
-            "horizontal_datum": datum,
-            "vertical_datum": record["alt_datum_cd"],
-            "aquifer": record["nat_aqfr_cd"],
-            "well_depth": record["well_depth_va"],
+            "horizontal_datum": "WGS84",
+            "vertical_datum": record["properties"]["vertical_datum"],
+            "aquifer": record["properties"]["national_aquifer_code"],
+            "well_depth": record["properties"]["well_constructed_depth"],
             "well_depth_units": "ft",
         }
         return rec

--- a/backend/connectors/usgs/transformer.py
+++ b/backend/connectors/usgs/transformer.py
@@ -29,7 +29,7 @@ class NWISSiteTransformer(SiteTransformer):
         datum = "WGS84"
 
         rec = {
-            "source": "USGS",
+            "source": "USGS-NWIS",
             "id": record["properties"]["monitoring_location_id"],
             "name": record["properties"]["monitoring_location_name"],
             "latitude": record["geometry"]["coordinates"][1],

--- a/backend/exceptions.py
+++ b/backend/exceptions.py
@@ -1,0 +1,2 @@
+class USGSRateLimitError(Exception):
+    pass

--- a/backend/exceptions.py
+++ b/backend/exceptions.py
@@ -1,5 +1,6 @@
 class USGSRateLimitError(Exception):
     pass
 
+
 class PartialOrNoDataError(Exception):
     pass

--- a/backend/exceptions.py
+++ b/backend/exceptions.py
@@ -1,2 +1,5 @@
 class USGSRateLimitError(Exception):
     pass
+
+class PartialOrNoDataError(Exception):
+    pass

--- a/backend/logger.py
+++ b/backend/logger.py
@@ -50,6 +50,11 @@ def setup_logging(level=None, log_format=None, path=None):
     root = logging.getLogger()
     root.setLevel(level)
 
+    # Remove any existing handlers to prevent file descriptor leaks
+    for handler in root.handlers[:]:
+        root.removeHandler(handler)
+        handler.close()
+
     if path is None:
         path = "die.log"
     else:

--- a/backend/logger.py
+++ b/backend/logger.py
@@ -20,6 +20,10 @@ import os
 import click
 
 
+# Track handlers created by this module to avoid closing unrelated handlers
+_managed_handlers = []
+
+
 class Loggable:
     def __init__(self):
         self.logger = logging.getLogger(self.__class__.__name__)
@@ -39,6 +43,7 @@ class Loggable:
 
 
 def setup_logging(level=None, log_format=None, path=None):
+    global _managed_handlers
 
     if level is None:
         level = logging.DEBUG
@@ -50,10 +55,11 @@ def setup_logging(level=None, log_format=None, path=None):
     root = logging.getLogger()
     root.setLevel(level)
 
-    # Remove any existing handlers to prevent file descriptor leaks
-    for handler in root.handlers[:]:
+    # Remove only the RotatingFileHandler instances we created
+    for handler in _managed_handlers:
         root.removeHandler(handler)
         handler.close()
+    _managed_handlers.clear()
 
     if path is None:
         path = "die.log"
@@ -62,6 +68,7 @@ def setup_logging(level=None, log_format=None, path=None):
 
     # shandler = logging.StreamHandler()
     rhandler = RotatingFileHandler(path, maxBytes=1e8, backupCount=50)
+    _managed_handlers.append(rhandler)
 
     handlers = [rhandler]
 

--- a/backend/source.py
+++ b/backend/source.py
@@ -19,6 +19,7 @@ import httpx
 import shapely.wkt
 from shapely import MultiPoint
 from typing import Union, List, Callable, Dict
+import time
 
 from backend.constants import (
     FEET,
@@ -200,7 +201,7 @@ class BaseSource(Loggable):
     # Methods Already Implemented
     # ==========================================================================
 
-    def _execute_text_request(self, url: str, params: dict | None = None, **kw) -> str:
+    def _execute_text_request(self, url: str, params: dict | None = None, max_tries: int = 7, **kw) -> str:
         """
         Executes a get request to the provided url and returns the text response.
 
@@ -212,6 +213,9 @@ class BaseSource(Loggable):
         params : dict
             key-value query parameters to pass to the get request
 
+        max_tries : int
+            the maximum number of times to retry the request if it fails
+
         Returns
         -------
         str
@@ -220,17 +224,32 @@ class BaseSource(Loggable):
         if "timeout" not in kw:
             kw["timeout"] = 10
 
-        resp = httpx.get(url, params=params, **kw)
-        if resp.status_code == 200:
-            return resp.text
-        else:
-            self.warn(f"service url {resp.url}")
-            self.warn(f"service responded with status {resp.status_code}")
-            self.warn(f"service responded with text {resp.text}")
+        tries: int = 0
+
+        while tries < max_tries:
+            try:
+                resp = httpx.get(url, params=params, **kw)
+                if resp.status_code == 200:
+                    return resp.text
+                else:
+                    self.warn(f"service responded with status {resp.status_code}")
+                    self.warn(f"service responded with text {resp.text}")
+                    self.warn(f"Retrying... {tries+1}/{max_tries}")
+            except Exception as e:
+                self.warn(f"Error during request: {e}")
+                self.warn(f"Retrying... {tries+1}/{max_tries}")
+            tries += 1
+            time.sleep(tries)
+
             return ""
 
     def _execute_json_request(
-        self, url: str, params: dict | None = None, tag: str | None = None, **kw
+        self,
+        url: str,
+        params: dict | None = None,
+        tag: str | None = None,
+        max_retries: int = 7,
+        **kw
     ) -> dict | None:
         """
         Executes a get request to the provided url and returns the json response.
@@ -245,30 +264,41 @@ class BaseSource(Loggable):
 
         tag : str
             the key to extract from the json response if required
+        
+        max_retries : int
+            the maximum number of times to retry the request if it fails
 
         Returns
         -------
         dict
             the json response
         """
-        resp = httpx.get(url, params=params, **kw)
-        if tag is None:
-            tag = "data"
-
-        if resp.status_code == 200:
+        tries: int = 0
+        while tries < max_retries:
             try:
-                obj = resp.json()
-                if tag and isinstance(obj, dict):
-                    return obj[tag]
-                return obj
-            except JSONDecodeError:
-                self.warn(f"service responded but with no data. \n{resp.text}")
-                return None
-        else:
-            self.warn(f"service responded with status {resp.status_code}")
-            self.warn(f"service responded with text {resp.text}")
-            self.warn(f"service at url:  {resp.url}")
-            return None
+                resp = httpx.get(url, params=params, **kw)
+                if tag is None:
+                    tag = "data"
+
+                if resp.status_code == 200:
+                    try:
+                        obj = resp.json()
+                        if tag and isinstance(obj, dict):
+                            return obj[tag]
+                        return obj
+                    except JSONDecodeError:
+                        self.warn(f"service responded but with no data. \n{resp.text}")
+                        return None
+                else:
+                    self.warn(f"service responded with status {resp.status_code}")
+                    self.warn(f"service responded with text {resp.text}")
+                    self.warn(f"Retrying... {tries+1}/{max_retries}")
+            except Exception as e:
+                self.warn(f"Error during request: {e}")
+                self.warn(f"Retrying... {tries+1}/{max_retries}")
+            tries += 1
+            time.sleep(tries)
+        return None
 
     # ==========================================================================
     # Methods Implemented in BaseSiteSource and BaseParameterSource

--- a/backend/source.py
+++ b/backend/source.py
@@ -252,9 +252,7 @@ class BaseSource(Loggable):
             the json response
         """
         resp = httpx.get(url, params=params, **kw)
-        if tag is None:
-            tag = "data"
-
+            
         if resp.status_code == 200:
             try:
                 obj = resp.json()

--- a/backend/source.py
+++ b/backend/source.py
@@ -234,6 +234,7 @@ class BaseSource(Loggable):
                 else:
                     self.warn(f"service responded with status {resp.status_code}")
                     self.warn(f"service responded with text {resp.text}")
+                    self.warn(f"URL: {url}")
                     self.warn(f"Retrying... {tries+1}/{max_tries}")
             except Exception as e:
                 self.warn(f"Error during request: {e}")
@@ -288,10 +289,12 @@ class BaseSource(Loggable):
                         return obj
                     except JSONDecodeError:
                         self.warn(f"service responded but with no data. \n{resp.text}")
+                        self.warn(f"URL: {url}")
                         return None
                 else:
                     self.warn(f"service responded with status {resp.status_code}")
-                    self.warn(f"service responded with text {resp.text}")
+                    self.warn(f"service responded with text {resp.text} for url {resp.url}")
+                    self.warn(f"URL: {url}")
                     self.warn(f"Retrying... {tries+1}/{max_retries}")
             except Exception as e:
                 self.warn(f"Error during request: {e}")

--- a/backend/source.py
+++ b/backend/source.py
@@ -241,7 +241,7 @@ class BaseSource(Loggable):
             tries += 1
             time.sleep(tries)
 
-            return ""
+        return ""
 
     def _execute_json_request(
         self,

--- a/backend/source.py
+++ b/backend/source.py
@@ -239,6 +239,7 @@ class BaseSource(Loggable):
                     self.warn(f"Retrying... {tries+1}/{max_tries}")
             except Exception as e:
                 self.warn(f"Error during request: {e}")
+                self.warn(f"URL: {url}")
                 self.warn(f"Retrying... {tries+1}/{max_tries}")
             tries += 1
             time.sleep(tries)
@@ -297,6 +298,7 @@ class BaseSource(Loggable):
                     self.warn(f"Retrying... {tries+1}/{max_retries}")
             except Exception as e:
                 self.warn(f"Error during request: {e}")
+                self.warn(f"URL: {url}")
                 self.warn(f"Retrying... {tries+1}/{max_retries}")
             tries += 1
             time.sleep(tries)

--- a/backend/source.py
+++ b/backend/source.py
@@ -252,7 +252,6 @@ class BaseSource(Loggable):
             the json response
         """
         resp = httpx.get(url, params=params, **kw)
-            
         if resp.status_code == 200:
             try:
                 obj = resp.json()

--- a/backend/source.py
+++ b/backend/source.py
@@ -288,9 +288,9 @@ class BaseSource(Loggable):
                             return obj[tag]
                         return obj
                     except JSONDecodeError:
-                        self.warn(f"service responded but with no data. \n{resp.text}")
+                        self.warn(f"service responded but with invalid or no JSON data. \n{resp.text}")
                         self.warn(f"URL: {url}")
-                        return None
+                        self.warn(f"Retrying... {tries+1}/{max_retries}")
                 else:
                     self.warn(f"service responded with status {resp.status_code}")
                     self.warn(f"service responded with text {resp.text} for url {resp.url}")

--- a/backend/source.py
+++ b/backend/source.py
@@ -254,7 +254,7 @@ class BaseSource(Loggable):
         tag: str | None = None,
         max_retries: int = 7,
         **kw
-    ) -> dict | None:
+    ) -> dict:
         """
         Executes a get request to the provided url and returns the json response.
 

--- a/backend/source.py
+++ b/backend/source.py
@@ -39,6 +39,7 @@ from backend.record import (
     SiteRecord,
 )
 from backend.transformer import BaseTransformer, convert_units
+from backend.exceptions import PartialOrNoDataError
 
 
 def make_site_list(site_record: list[SiteRecord] | SiteRecord) -> list | str:
@@ -242,7 +243,8 @@ class BaseSource(Loggable):
             tries += 1
             time.sleep(tries)
 
-        return ""
+        self.warn("Failed to retrieve records after multiple attempts")
+        raise PartialOrNoDataError("Failed to retrieve records after multiple attempts")
 
     def _execute_json_request(
         self,
@@ -292,14 +294,15 @@ class BaseSource(Loggable):
                 else:
                     self.warn(f"service responded with status {resp.status_code}")
                     self.warn(f"service responded with text {resp.text} for url {resp.url}")
-                    self.warn(f"URL: {url}")
                     self.warn(f"Retrying... {tries+1}/{max_retries}")
             except Exception as e:
                 self.warn(f"Error during request: {e}")
                 self.warn(f"Retrying... {tries+1}/{max_retries}")
             tries += 1
             time.sleep(tries)
-        return None
+        
+        self.warn("Failed to retrieve records after multiple attempts")
+        raise PartialOrNoDataError("Failed to retrieve records after multiple attempts")
 
     # ==========================================================================
     # Methods Implemented in BaseSiteSource and BaseParameterSource

--- a/backend/transformer.py
+++ b/backend/transformer.py
@@ -259,6 +259,7 @@ def standardize_datetime(dt, record_id):
             "%Y-%m-%dT%H:%M:%S",
             "%Y-%m-%dT%H:%M:%S.%fZ",
             "%Y-%m-%dT%H:%M:%SZ",
+            "%Y-%m-%dT%H:%M:%S+00:00",
             "%Y-%m-%d %H:%M:%S",
             "%Y-%m-%d %H:%M:%S+00:00",
             "%Y-%m-%d %H:%M",

--- a/backend/unifier.py
+++ b/backend/unifier.py
@@ -21,7 +21,7 @@ from backend.constants import WATERLEVELS
 from backend.persister import BasePersister
 from backend.persisters.geoserver import GeoServerPersister
 from backend.source import BaseSiteSource
-from backend.exceptions import USGSRateLimitError
+from backend.exceptions import USGSRateLimitError, PartialOrNoDataError
 
 
 def health_check(source: BaseSiteSource) -> bool | None:
@@ -171,8 +171,8 @@ def _site_wrapper(site_source, parameter_source, persister, config):
                         summary_records = parameter_source.read(
                             site_records, use_summarize, start_ind, end_ind
                         )
-                    except USGSRateLimitError:
-                        # if a rate limit error is hit we want to remove USGS sites so there aren't partial records
+                    except (USGSRateLimitError, PartialOrNoDataError):
+                        # remove partial records to prevent incomplete data from being saved
                         persister.sites = persister.sites[:initial_sites_len]
                         persister.timeseries = persister.timeseries[:initial_timeseries_len]
                         persister.records = persister.records[:initial_records_len]
@@ -187,8 +187,8 @@ def _site_wrapper(site_source, parameter_source, persister, config):
                         results = parameter_source.read(
                             site_records, use_summarize, start_ind, end_ind
                         )
-                    except USGSRateLimitError:
-                        # if a rate limit error is hit we want to remove USGS sites so there aren't partial records
+                    except (USGSRateLimitError, PartialOrNoDataError):
+                        # remove partial records to prevent incomplete data from being saved
                         persister.sites = persister.sites[:initial_sites_len]
                         persister.timeseries = persister.timeseries[:initial_timeseries_len]
                         break

--- a/backend/unifier.py
+++ b/backend/unifier.py
@@ -137,12 +137,16 @@ def _site_wrapper(site_source, parameter_source, persister, config):
         initial_timeseries_len = len(persister.timeseries)
         initial_records_len = len(persister.records)
 
+        incomplete_sites_record_msg = f"Failed to retrieve complete site records for {site_source}. No records will be saved for this source."
+        incomplete_parameter_record_msg = f"Failed to retrieve complete parameter records for {site_source}. No records will be saved for this source."
+
         use_summarize = config.output_summary
         site_limit = config.site_limit
 
         try:
             sites = site_source.read()
         except (USGSRateLimitError, PartialOrNoDataError):
+            config.warn(incomplete_sites_record_msg)
             sites = []
 
         if not sites:
@@ -176,7 +180,7 @@ def _site_wrapper(site_source, parameter_source, persister, config):
                         persister.sites = persister.sites[:initial_sites_len]
                         persister.timeseries = persister.timeseries[:initial_timeseries_len]
                         persister.records = persister.records[:initial_records_len]
-                        config.warn(f"Failed to retrieve complete records after multiple attempts for {site_source}. No records will be saved for this source.")
+                        config.warn(incomplete_parameter_record_msg)
                         break
                     if summary_records:
                         persister.records.extend(summary_records)
@@ -193,13 +197,12 @@ def _site_wrapper(site_source, parameter_source, persister, config):
                         persister.sites = persister.sites[:initial_sites_len]
                         persister.timeseries = persister.timeseries[:initial_timeseries_len]
                         persister.records = persister.records[:initial_records_len]
-                        config.warn(f"Failed to retrieve complete records after multiple attempts for {site_source}. No records will be saved for this source.")
+                        config.warn(incomplete_parameter_record_msg)
                         break
                     # no records are returned if there is no site record for parameter
                     # or if the record isn't clean (doesn't have the correct fields)
                     # don't count these sites to apply to site_limit
                     if results is None or len(results) == 0:
-                        config.warn(f"No valid records retrieved for {site_source}. No records will be saved for this source.")
                         continue
                     else:
                         sites_with_records_count += len(results)

--- a/backend/unifier.py
+++ b/backend/unifier.py
@@ -21,6 +21,7 @@ from backend.constants import WATERLEVELS
 from backend.persister import BasePersister
 from backend.persisters.geoserver import GeoServerPersister
 from backend.source import BaseSiteSource
+from backend.connectors.usgs.source import USGSRateLimitError
 
 
 def health_check(source: BaseSiteSource) -> bool | None:
@@ -131,10 +132,17 @@ def _site_wrapper(site_source, parameter_source, persister, config):
         # in the future make discover required
         # return
 
+        # used to revert back to initial state if a rate limit error is hit, so there aren't partial records
+        initial_sites_len = len(persister.sites)
+        initial_timeseries_len = len(persister.timeseries)
+
         use_summarize = config.output_summary
         site_limit = config.site_limit
 
-        sites = site_source.read()
+        try:
+            sites = site_source.read()
+        except USGSRateLimitError:
+            sites = []
 
         if not sites:
             return
@@ -158,18 +166,30 @@ def _site_wrapper(site_source, parameter_source, persister, config):
                     end_ind += n
 
                 if use_summarize:
-                    summary_records = parameter_source.read(
-                        site_records, use_summarize, start_ind, end_ind
-                    )
+                    try:
+                        summary_records = parameter_source.read(
+                            site_records, use_summarize, start_ind, end_ind
+                        )
+                    except USGSRateLimitError:
+                        # if a rate limit error is hit we want to remove USGS sites so there aren't partial records
+                        persister.sites = persister.sites[:initial_sites_len]
+                        persister.timeseries = persister.timeseries[:initial_timeseries_len]
+                        break
                     if summary_records:
                         persister.records.extend(summary_records)
                         sites_with_records_count += len(summary_records)
                     else:
                         continue
                 else:
-                    results = parameter_source.read(
-                        site_records, use_summarize, start_ind, end_ind
-                    )
+                    try:
+                        results = parameter_source.read(
+                            site_records, use_summarize, start_ind, end_ind
+                        )
+                    except USGSRateLimitError:
+                        # if a rate limit error is hit we want to remove USGS sites so there aren't partial records
+                        persister.sites = persister.sites[:initial_sites_len]
+                        persister.timeseries = persister.timeseries[:initial_timeseries_len]
+                        break
                     # no records are returned if there is no site record for parameter
                     # or if the record isn't clean (doesn't have the correct fields)
                     # don't count these sites to apply to site_limit

--- a/backend/unifier.py
+++ b/backend/unifier.py
@@ -21,7 +21,7 @@ from backend.constants import WATERLEVELS
 from backend.persister import BasePersister
 from backend.persisters.geoserver import GeoServerPersister
 from backend.source import BaseSiteSource
-from backend.connectors.usgs.source import USGSRateLimitError
+from backend.exceptions import USGSRateLimitError
 
 
 def health_check(source: BaseSiteSource) -> bool | None:

--- a/backend/unifier.py
+++ b/backend/unifier.py
@@ -135,6 +135,7 @@ def _site_wrapper(site_source, parameter_source, persister, config):
         # used to revert back to initial state if a rate limit error is hit, so there aren't partial records
         initial_sites_len = len(persister.sites)
         initial_timeseries_len = len(persister.timeseries)
+        initial_records_len = len(persister.records)
 
         use_summarize = config.output_summary
         site_limit = config.site_limit
@@ -174,6 +175,7 @@ def _site_wrapper(site_source, parameter_source, persister, config):
                         # if a rate limit error is hit we want to remove USGS sites so there aren't partial records
                         persister.sites = persister.sites[:initial_sites_len]
                         persister.timeseries = persister.timeseries[:initial_timeseries_len]
+                        persister.records = persister.records[:initial_records_len]
                         break
                     if summary_records:
                         persister.records.extend(summary_records)

--- a/backend/unifier.py
+++ b/backend/unifier.py
@@ -176,6 +176,7 @@ def _site_wrapper(site_source, parameter_source, persister, config):
                         persister.sites = persister.sites[:initial_sites_len]
                         persister.timeseries = persister.timeseries[:initial_timeseries_len]
                         persister.records = persister.records[:initial_records_len]
+                        config.warn(f"Failed to retrieve complete records after multiple attempts for {site_source}. No records will be saved for this source.")
                         break
                     if summary_records:
                         persister.records.extend(summary_records)
@@ -192,11 +193,13 @@ def _site_wrapper(site_source, parameter_source, persister, config):
                         persister.sites = persister.sites[:initial_sites_len]
                         persister.timeseries = persister.timeseries[:initial_timeseries_len]
                         persister.records = persister.records[:initial_records_len]
+                        config.warn(f"Failed to retrieve complete records after multiple attempts for {site_source}. No records will be saved for this source.")
                         break
                     # no records are returned if there is no site record for parameter
                     # or if the record isn't clean (doesn't have the correct fields)
                     # don't count these sites to apply to site_limit
                     if results is None or len(results) == 0:
+                        config.warn(f"No valid records retrieved for {site_source}. No records will be saved for this source.")
                         continue
                     else:
                         sites_with_records_count += len(results)

--- a/backend/unifier.py
+++ b/backend/unifier.py
@@ -191,6 +191,7 @@ def _site_wrapper(site_source, parameter_source, persister, config):
                         # remove partial records to prevent incomplete data from being saved
                         persister.sites = persister.sites[:initial_sites_len]
                         persister.timeseries = persister.timeseries[:initial_timeseries_len]
+                        persister.records = persister.records[:initial_records_len]
                         break
                     # no records are returned if there is no site record for parameter
                     # or if the record isn't clean (doesn't have the correct fields)

--- a/backend/unifier.py
+++ b/backend/unifier.py
@@ -142,7 +142,7 @@ def _site_wrapper(site_source, parameter_source, persister, config):
 
         try:
             sites = site_source.read()
-        except USGSRateLimitError:
+        except (USGSRateLimitError, PartialOrNoDataError):
             sites = []
 
         if not sites:

--- a/frontend/cli.py
+++ b/frontend/cli.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ===============================================================================
-import sys
+import os
 
 import click
 
@@ -206,6 +206,13 @@ CONFIG_PATH_OPTIONS = [
     ),
 ]
 
+USGS_API_KEY_OPTION = [
+    click.option(
+        "--usgs-api-key",
+        default=None,
+        help="USGS API key. Can also be set via USGS_API_KEY environment variable",
+    )
+]
 
 def add_options(options):
     def _add_options(func):
@@ -230,6 +237,7 @@ def add_options(options):
 @add_options(ALL_SOURCE_OPTIONS)
 @add_options(DEBUG_OPTIONS)
 @add_options(OUTPUT_FORMAT_OPTIONS)
+@add_options(USGS_API_KEY_OPTION)
 def weave(
     parameter,
     config_path,
@@ -256,10 +264,15 @@ def weave(
     dry,
     yes,
     output_format,
+    usgs_api_key,
 ):
     """
     Get parameter timeseries or summary data
     """
+    # set USGS_API_KEY environment variable if usgs_api_key is provided
+    if usgs_api_key is not None:
+        os.environ["USGS_API_KEY"] = usgs_api_key
+
     # instantiate config and set up parameter
     config = setup_config(
         tag=parameter,
@@ -334,6 +347,7 @@ def weave(
 @add_options(ALL_SOURCE_OPTIONS)
 @add_options(DEBUG_OPTIONS)
 @add_options(OUTPUT_FORMAT_OPTIONS)
+@add_options(USGS_API_KEY_OPTION)
 def sites(
     config_path,
     bbox,
@@ -356,10 +370,15 @@ def sites(
     dry,
     yes,
     output_format,
+    usgs_api_key,
 ):
     """
     Get sites
     """
+    # set USGS_API_KEY environment variable if usgs_api_key is provided
+    if usgs_api_key is not None:
+        os.environ["USGS_API_KEY"] = usgs_api_key
+
     config = setup_config(
         "sites", config_path, bbox, county, wkt, site_limit, dry, output_format
     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 click==8.2.1
-dotenv
+python-dotenv
 flask
 frost_sta_client
 Geoalchemy2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 click==8.2.1
+dotenv
 flask
 frost_sta_client
 Geoalchemy2

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     ],
     install_requires=[
         "click==8.2.1",
-        "dotenv",
+        "python-dotenv",
         "flask",
         "frost_sta_client",
         "Geoalchemy2",

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
     ],
     install_requires=[
         "click==8.2.1",
+        "dotenv",
         "flask",
         "frost_sta_client",
         "Geoalchemy2",

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="nmuwd",
-    version="0.10.0",
+    version="0.10.1",
     author="Jake Ross",
     description="New Mexico Water Data Integration Engine",
     long_description=long_description,

--- a/tests/test_cli/__init__.py
+++ b/tests/test_cli/__init__.py
@@ -102,6 +102,8 @@ class BaseCLITestClass:
 
         arguments.extend(no_agencies)
 
+        # save original USGS_API_KEY to reset after test, and set to test value if provided
+        original_usgs_api_key = os.getenv("USGS_API_KEY", None)
         if usgs_api_key:
             arguments.extend(["--usgs-api-key", usgs_api_key])
 
@@ -186,6 +188,11 @@ class BaseCLITestClass:
             # 10
             if usgs_api_key:
                 assert os.getenv("USGS_API_KEY") == usgs_api_key
+
+                if original_usgs_api_key is not None:
+                    os.environ["USGS_API_KEY"] = original_usgs_api_key
+                else:
+                    del os.environ["USGS_API_KEY"]
         except Exception as e:
             print(result)
             assert False

--- a/tests/test_cli/__init__.py
+++ b/tests/test_cli/__init__.py
@@ -189,13 +189,15 @@ class BaseCLITestClass:
             if usgs_api_key:
                 assert os.getenv("USGS_API_KEY") == usgs_api_key
 
-                if original_usgs_api_key is not None:
-                    os.environ["USGS_API_KEY"] = original_usgs_api_key
-                else:
-                    del os.environ["USGS_API_KEY"]
         except Exception as e:
             print(result)
             assert False
+        finally:
+            # reset USGS_API_KEY to original value after test
+            if original_usgs_api_key is not None:
+                os.environ["USGS_API_KEY"] = original_usgs_api_key
+            else:
+                os.environ.pop("USGS_API_KEY", None)
 
     def test_weave_summary(self):
         self._test_weave(parameter=WATERLEVELS, output_type="summary")

--- a/tests/test_cli/__init__.py
+++ b/tests/test_cli/__init__.py
@@ -3,6 +3,7 @@ from logging import shutdown as logger_shutdown
 from pathlib import Path
 import pytest
 from typing import List
+import os
 
 from backend.config import SOURCE_KEYS
 from backend.constants import (
@@ -57,6 +58,7 @@ class BaseCLITestClass:
         bbox: str | None = None,
         county: str | None = None,
         wkt: str | None = None,
+        usgs_api_key: str | None = None,
     ):
         # Arrange
         # turn off all sources except for the one being tested
@@ -99,6 +101,9 @@ class BaseCLITestClass:
             arguments.extend([f"--{geographic_filter_name}", geographic_filter_value])
 
         arguments.extend(no_agencies)
+
+        if usgs_api_key:
+            arguments.extend(["--usgs-api-key", usgs_api_key])
 
         # Act
         result = self.runner.invoke(weave, arguments, standalone_mode=False)
@@ -177,6 +182,10 @@ class BaseCLITestClass:
 
             # 9
             assert getattr(config, "output_format") == output_format
+
+            # 10
+            if usgs_api_key:
+                assert os.getenv("USGS_API_KEY") == usgs_api_key
         except Exception as e:
             print(result)
             assert False
@@ -215,6 +224,13 @@ class BaseCLITestClass:
             parameter=WATERLEVELS,
             output_type="summary",
             wkt="POLYGON((-106.0 32.0, -102.0 32.0, -102.0 36.0, -106.0 36.0, -106.0 32.0))",
+        )
+
+    def test_weave_usgs_api_key(self):
+        self._test_weave(
+            parameter=WATERLEVELS,
+            output_type="summary",
+            usgs_api_key="TEST_API_KEY",
         )
 
     def test_weave_waterlevels(self):

--- a/tests/test_sources/test_nmbgmr_amp.py
+++ b/tests/test_sources/test_nmbgmr_amp.py
@@ -8,7 +8,7 @@ os.environ["IS_TESTING_ENV"] = "True"
 
 
 @pytest.fixture(autouse=True)
-def setup():
+def setup_nmbgmr_amp():
     # SETUP CODE -----------------------------------------------------------
     os.environ["IS_TESTING_ENV"] = "True"
 

--- a/tests/test_sources/test_nmbgmr_amp.py
+++ b/tests/test_sources/test_nmbgmr_amp.py
@@ -4,9 +4,6 @@ import pytest
 from backend.constants import WATERLEVELS, CALCIUM, MILLIGRAMS_PER_LITER, FEET
 from tests.test_sources import BaseSourceTestClass
 
-os.environ["IS_TESTING_ENV"] = "True"
-
-
 @pytest.fixture(autouse=True)
 def setup_nmbgmr_amp():
     # SETUP CODE -----------------------------------------------------------

--- a/tests/test_sources/test_nwis.py
+++ b/tests/test_sources/test_nwis.py
@@ -6,7 +6,7 @@ from backend.constants import WATERLEVELS, FEET
 from tests.test_sources import BaseSourceTestClass
 
 @pytest.fixture(autouse=True)
-def setup():
+def setup_nwis():
     # SETUP CODE -----------------------------------------------------------
     load_dotenv()
 

--- a/tests/test_sources/test_nwis.py
+++ b/tests/test_sources/test_nwis.py
@@ -1,6 +1,20 @@
+import os
+from dotenv import load_dotenv
+import pytest
+
 from backend.constants import WATERLEVELS, FEET
 from tests.test_sources import BaseSourceTestClass
 
+@pytest.fixture(autouse=True)
+def setup():
+    # SETUP CODE -----------------------------------------------------------
+    load_dotenv()
+
+    # RUN TESTS ------------------------------------------------------------
+    yield
+
+    # TEARDOWN CODE ---------------------------------------------------------
+    os.environ["USGS_API_KEY"] = ""
 
 class TestNWISWaterlevels(BaseSourceTestClass):
 

--- a/tests/test_sources/test_nwis.py
+++ b/tests/test_sources/test_nwis.py
@@ -8,13 +8,18 @@ from tests.test_sources import BaseSourceTestClass
 @pytest.fixture(autouse=True)
 def setup_nwis():
     # SETUP CODE -----------------------------------------------------------
+    had_usgs_api_key = "USGS_API_KEY" in os.environ
+    original_usgs_api_key = os.environ.get("USGS_API_KEY")
     load_dotenv(override=True)
 
     # RUN TESTS ------------------------------------------------------------
     yield
 
     # TEARDOWN CODE ---------------------------------------------------------
-    os.environ["USGS_API_KEY"] = ""
+    if had_usgs_api_key:
+         os.environ["USGS_API_KEY"] = original_usgs_api_key
+    else:
+        os.environ.pop("USGS_API_KEY", None)
 
 class TestNWISWaterlevels(BaseSourceTestClass):
 

--- a/tests/test_sources/test_nwis.py
+++ b/tests/test_sources/test_nwis.py
@@ -8,18 +8,15 @@ from tests.test_sources import BaseSourceTestClass
 @pytest.fixture(autouse=True)
 def setup_nwis():
     # SETUP CODE -----------------------------------------------------------
-    had_usgs_api_key = "USGS_API_KEY" in os.environ
-    original_usgs_api_key = os.environ.get("USGS_API_KEY")
+    original_environ = os.environ.copy()
     load_dotenv(override=True)
 
     # RUN TESTS ------------------------------------------------------------
     yield
 
     # TEARDOWN CODE ---------------------------------------------------------
-    if had_usgs_api_key:
-         os.environ["USGS_API_KEY"] = original_usgs_api_key
-    else:
-        os.environ.pop("USGS_API_KEY", None)
+    os.environ.clear()
+    os.environ.update(original_environ)
 
 class TestNWISWaterlevels(BaseSourceTestClass):
 

--- a/tests/test_sources/test_nwis.py
+++ b/tests/test_sources/test_nwis.py
@@ -8,7 +8,7 @@ from tests.test_sources import BaseSourceTestClass
 @pytest.fixture(autouse=True)
 def setup_nwis():
     # SETUP CODE -----------------------------------------------------------
-    load_dotenv()
+    load_dotenv(override=True)
 
     # RUN TESTS ------------------------------------------------------------
     yield


### PR DESCRIPTION
<!--
- Title the PR with the JIRA project & ticket number and short description (e.g., BDMS-123: Example display bug), or NO TICKET
- Keep sections short and scannable.
-->
### **Why**
_This PR addresses the following problem / context:_
- The USGS is in the process of or has already deprecated water services APIs. We need to use their new APIs
- We should be able to pass a tag of `None` to the `_execute_json_request` method when we need to use the full response object, such as `features` and `links`
- BoR does not report bicarbonate data, so it should not be queryable when running the DIE for bicarbonate
- NMBGMR needs a larger timeout for water level data
- the `_execute_json_request` and `_execute_text_request` methods should raise errors if unsuccessful instead of returning empty datasets. This prevents partial data sets from being accidentally returned

### **How**
_Implementation summary - the following was changed / added / removed:_

#### USGS

There are two issues that needed to be resolved when retrieving USGS data:
1. I needed to get all records, with or without pagination.
2. I needed to stay within the allowed request rate limit.

It turns out that both of these issues could be addressed with the same solution: set the `limit` query parameter to the maximum allowed (50,000). By doing this I would get all of the records back in one page and I would severely cut the number of necessary requests. 

It also turns out, however, that if I use the `limit` query parameter in a POST request the cursor-based pagination breaks. I'm not sure why, but if `limit` is less than the expected number of records pagination returns _all_ USGS records and doesn't apply the filters. There are ~32,000 wells in NM that have groundwater field measurements, and I can get measurements for up to 250 wells at a time, so using `?limit=50000` in my GET and POST requests should be safe for a very long time. Nevertheless, I have commented-out code that can handle pagination if/when it is fixed.

#### _execute_json_request tags

Previously if no tag was specified (i.e. set or defaulted to `None`) then the method `_execute_json_request` would default to `tag` to `"data"`. This had the unintended consequence of disallowing multiple keys to be used to access data from the response object, such as `"features"` and `"links"` (the latter used to follow pagination). This default was removed, allowing the full response object to be returned. I then updated **BoR** and **NMOSE ISC Seven Rivers** to explicitly set `tag="data"` when invoking the `_execute_json_request` method. 

### **Notes**
_Any special considerations, workarounds, or follow-up work to note?_
- Use bullet points here
