### PR TITLE
NMBGMR Timeout fix

### DIFF
--- a/backend/connectors/nmbgmr/source.py
+++ b/backend/connectors/nmbgmr/source.py
@@ -88,19 +88,9 @@ class NMBGMRSiteSource(BaseSiteSource):
             else:
                 params["parameter"] = "Manual groundwater levels"
 
-        # tags="features" because the response object is a GeoJSON
-        request_finished: bool = False
-        while not request_finished:
-            try:
-                sites = self._execute_json_request(
-                    _make_url("locations"), params, tag="features", timeout=TIMEOUT
-                )
-                if sites is None:
-                    self.warn("Retrying...")
-                    continue
-                request_finished = True
-            except Exception as e:
-                self.warn(f"Error retrieving site data: {e}. Retrying...")
+        sites = self._execute_json_request(
+            _make_url("locations"), params, tag="features", timeout=TIMEOUT
+        )
 
         if not config.sites_only:
             for site in sites:
@@ -136,25 +126,16 @@ class NMBGMRAnalyteSource(BaseAnalyteSource):
             self.config.parameter, NMBGMR_ANALYTE_MAPPING
         )
 
-        request_finished: bool = False
+        records = self._execute_json_request(
+            _make_url("waterchemistry"),
+            params={
+                "pointid": ",".join(make_site_list(site_record)),
+                "analyte": analyte,
+            },
+            tag="",
+            timeout=TIMEOUT
+        )
 
-        while not request_finished:
-            try:
-                records = self._execute_json_request(
-                    _make_url("waterchemistry"),
-                    params={
-                        "pointid": ",".join(make_site_list(site_record)),
-                        "analyte": analyte,
-                    },
-                    tag="",
-                    timeout=TIMEOUT
-                )
-                if records is None:
-                    self.warn("Retrying...")
-                    continue
-                request_finished = True
-            except Exception as e:
-                self.warn(f"Error retrieving analyte data: {e}. Retrying...")
         records_sorted_by_pointid = {}
         for pointid in records.keys():
             records_sorted_by_pointid[pointid] = records[pointid][analyte]
@@ -252,16 +233,8 @@ class NMBGMRWaterLevelSource(BaseWaterLevelSource):
         # just use manual waterlevels temporarily
         url = _make_url("waterlevels/manual")
 
-        request_finished: bool = False
-        while not request_finished:
-             try:
-                paginated_records = self._execute_json_request(url, params, tag="", timeout=TIMEOUT)
-                if paginated_records is None:
-                    self.warn("Retrying...")
-                    continue
-                request_finished = True
-             except Exception as e:
-                self.warn(f"Error retrieving water level data: {e}. Retrying...")
+        paginated_records = self._execute_json_request(url, params, tag="", timeout=TIMEOUT)
+
         items = paginated_records["items"]
         page = paginated_records["page"]
         pages = paginated_records["pages"]
@@ -270,17 +243,7 @@ class NMBGMRWaterLevelSource(BaseWaterLevelSource):
             page += 1
             params["page"] = page
 
-            request_finished: bool = False
-            while not request_finished:
-                try:
-                    new_records = self._execute_json_request(url, params, tag="", timeout=TIMEOUT)
-                    # status_code != 200 makes _execute_json_request return None, so check for that and retry if it happens
-                    if new_records is None:
-                        self.warn("Retrying...")
-                        continue
-                    request_finished = True
-                except Exception as e:
-                    self.warn(f"Error retrieving page {page} of water level data: {e}. Retrying...")
+            new_records = self._execute_json_request(url, params, tag="", timeout=TIMEOUT)
             
             items.extend(new_records["items"])
             pages = new_records["pages"]

--- a/backend/connectors/nmbgmr/source.py
+++ b/backend/connectors/nmbgmr/source.py
@@ -95,11 +95,11 @@ class NMBGMRSiteSource(BaseSiteSource):
                     _make_url("locations"), params, tag="features", timeout=TIMEOUT
                 )
                 if sites is None:
-                    self.warning("Retrying...")
+                    self.warn("Retrying...")
                     continue
                 request_finished = True
             except Exception as e:
-                self.warning(f"Error retrieving site data: {e}. Retrying...")
+                self.warn(f"Error retrieving site data: {e}. Retrying...")
 
         if not config.sites_only:
             for site in sites:
@@ -149,11 +149,11 @@ class NMBGMRAnalyteSource(BaseAnalyteSource):
                     timeout=TIMEOUT
                 )
                 if records is None:
-                    self.warning("Retrying...")
+                    self.warn("Retrying...")
                     continue
                 request_finished = True
             except Exception as e:
-                self.warning(f"Error retrieving analyte data: {e}. Retrying...")
+                self.warn(f"Error retrieving analyte data: {e}. Retrying...")
         records_sorted_by_pointid = {}
         for pointid in records.keys():
             records_sorted_by_pointid[pointid] = records[pointid][analyte]
@@ -256,11 +256,11 @@ class NMBGMRWaterLevelSource(BaseWaterLevelSource):
              try:
                 paginated_records = self._execute_json_request(url, params, tag="", timeout=TIMEOUT)
                 if paginated_records is None:
-                    self.warning("Retrying...")
+                    self.warn("Retrying...")
                     continue
                 request_finished = True
              except Exception as e:
-                self.warning(f"Error retrieving water level data: {e}. Retrying...")
+                self.warn(f"Error retrieving water level data: {e}. Retrying...")
         items = paginated_records["items"]
         page = paginated_records["page"]
         pages = paginated_records["pages"]
@@ -275,11 +275,11 @@ class NMBGMRWaterLevelSource(BaseWaterLevelSource):
                     new_records = self._execute_json_request(url, params, tag="", timeout=TIMEOUT)
                     # status_code != 200 makes _execute_json_request return None, so check for that and retry if it happens
                     if new_records is None:
-                        self.warning("Retrying...")
+                        self.warn("Retrying...")
                         continue
                     request_finished = True
                 except Exception as e:
-                    self.warning(f"Error retrieving page {page} of water level data: {e}. Retrying...")
+                    self.warn(f"Error retrieving page {page} of water level data: {e}. Retrying...")
             
             items.extend(new_records["items"])
             pages = new_records["pages"]

--- a/backend/connectors/nmbgmr/source.py
+++ b/backend/connectors/nmbgmr/source.py
@@ -49,7 +49,7 @@ from backend.source import (
 # Don't use timeout=None since that can cause the request to hang indefinitely if there are issues with the API.
 # Instead, catch timeout exceptions and retry the request until it succeeds or a different exception is raised.
 
-TIMEOUT=1800
+TIMEOUT=15*60
 
 def _make_url(endpoint):
     if os.getenv("DEBUG") == "1":

--- a/backend/connectors/nmbgmr/source.py
+++ b/backend/connectors/nmbgmr/source.py
@@ -94,6 +94,9 @@ class NMBGMRSiteSource(BaseSiteSource):
                 sites = self._execute_json_request(
                     _make_url("locations"), params, tag="features", timeout=TIMEOUT
                 )
+                if sites is None:
+                    self.warning("Retrying...")
+                    continue
                 request_finished = True
             except Exception as e:
                 self.warning(f"Error retrieving site data: {e}. Retrying...")
@@ -145,6 +148,9 @@ class NMBGMRAnalyteSource(BaseAnalyteSource):
                     tag="",
                     timeout=TIMEOUT
                 )
+                if records is None:
+                    self.warning("Retrying...")
+                    continue
                 request_finished = True
             except Exception as e:
                 self.warning(f"Error retrieving analyte data: {e}. Retrying...")
@@ -250,6 +256,9 @@ class NMBGMRWaterLevelSource(BaseWaterLevelSource):
         while not request_finished:
              try:
                 paginated_records = self._execute_json_request(url, params, tag="", timeout=TIMEOUT)
+                if paginated_records is None:
+                    self.warning("Retrying...")
+                    continue
                 request_finished = True
              except Exception as e:
                 self.warning(f"Error retrieving water level data: {e}. Retrying...")

--- a/backend/connectors/nmbgmr/source.py
+++ b/backend/connectors/nmbgmr/source.py
@@ -248,7 +248,6 @@ class NMBGMRWaterLevelSource(BaseWaterLevelSource):
         #     url = _make_url("waterlevels/latest")
         # else:
         params = {"pointid": ",".join(make_site_list(site_record))}
-        print(make_site_list(site_record))
         # just use manual waterlevels temporarily
         url = _make_url("waterlevels/manual")
 

--- a/backend/connectors/nmbgmr/source.py
+++ b/backend/connectors/nmbgmr/source.py
@@ -44,10 +44,11 @@ from backend.source import (
     make_site_list,
 )
 
-"""
-Set timeout to 30 minutes for analyte and water level requests since some sites have a large number of records and the NMBGMR API can be slow to respond.
-Don't use timeout=None since that can cause the request to hang indefinitely if there are issues with the API. Instead, catch timeout exceptions and retry the request until it succeeds or a different exception is raised.
-"""
+
+# Set timeout to 30 minutes for analyte and water level requests since some sites have a large number of records and the NMBGMR API can be slow to respond.
+# Don't use timeout=None since that can cause the request to hang indefinitely if there are issues with the API.
+# Instead, catch timeout exceptions and retry the request until it succeeds or a different exception is raised.
+
 TIMEOUT=1800
 
 def _make_url(endpoint):

--- a/backend/connectors/nmbgmr/source.py
+++ b/backend/connectors/nmbgmr/source.py
@@ -44,6 +44,11 @@ from backend.source import (
     make_site_list,
 )
 
+"""
+Set timeout to 30 minutes for analyte and water level requests since some sites have a large number of records and the NMBGMR API can be slow to respond.
+Don't use timeout=None since that can cause the request to hang indefinitely if there are issues with the API. Instead, catch timeout exceptions and retry the request until it succeeds or a different exception is raised.
+"""
+TIMEOUT=1800
 
 def _make_url(endpoint):
     if os.getenv("DEBUG") == "1":
@@ -83,9 +88,16 @@ class NMBGMRSiteSource(BaseSiteSource):
                 params["parameter"] = "Manual groundwater levels"
 
         # tags="features" because the response object is a GeoJSON
-        sites = self._execute_json_request(
-            _make_url("locations"), params, tag="features", timeout=30
-        )
+        request_finished: bool = False
+        while not request_finished:
+            try:
+                sites = self._execute_json_request(
+                    _make_url("locations"), params, tag="features", timeout=TIMEOUT
+                )
+                request_finished = True
+            except Exception as e:
+                self.warning(f"Error retrieving site data: {e}. Retrying...")
+
         if not config.sites_only:
             for site in sites:
                 if get_bool_env_variable("IS_TESTING_ENV"):
@@ -119,14 +131,23 @@ class NMBGMRAnalyteSource(BaseAnalyteSource):
         analyte = get_analyte_search_param(
             self.config.parameter, NMBGMR_ANALYTE_MAPPING
         )
-        records = self._execute_json_request(
-            _make_url("waterchemistry"),
-            params={
-                "pointid": ",".join(make_site_list(site_record)),
-                "analyte": analyte,
-            },
-            tag="",
-        )
+
+        request_finished: bool = False
+
+        while not request_finished:
+            try:
+                records = self._execute_json_request(
+                    _make_url("waterchemistry"),
+                    params={
+                        "pointid": ",".join(make_site_list(site_record)),
+                        "analyte": analyte,
+                    },
+                    tag="",
+                    timeout=TIMEOUT
+                )
+                request_finished = True
+            except Exception as e:
+                self.warning(f"Error retrieving analyte data: {e}. Retrying...")
         records_sorted_by_pointid = {}
         for pointid in records.keys():
             records_sorted_by_pointid[pointid] = records[pointid][analyte]
@@ -221,10 +242,17 @@ class NMBGMRWaterLevelSource(BaseWaterLevelSource):
         #     url = _make_url("waterlevels/latest")
         # else:
         params = {"pointid": ",".join(make_site_list(site_record))}
+        print(make_site_list(site_record))
         # just use manual waterlevels temporarily
         url = _make_url("waterlevels/manual")
 
-        paginated_records = self._execute_json_request(url, params, tag="")
+        request_finished: bool = False
+        while not request_finished:
+             try:
+                paginated_records = self._execute_json_request(url, params, tag="", timeout=TIMEOUT)
+                request_finished = True
+             except Exception as e:
+                self.warning(f"Error retrieving water level data: {e}. Retrying...")
         items = paginated_records["items"]
         page = paginated_records["page"]
         pages = paginated_records["pages"]
@@ -232,7 +260,19 @@ class NMBGMRWaterLevelSource(BaseWaterLevelSource):
         while page < pages:
             page += 1
             params["page"] = page
-            new_records = self._execute_json_request(url, params, tag="")
+
+            request_finished: bool = False
+            while not request_finished:
+                try:
+                    new_records = self._execute_json_request(url, params, tag="", timeout=TIMEOUT)
+                    # status_code != 200 makes _execute_json_request return None, so check for that and retry if it happens
+                    if new_records is None:
+                        self.warning("Retrying...")
+                        continue
+                    request_finished = True
+                except Exception as e:
+                    self.warning(f"Error retrieving page {page} of water level data: {e}. Retrying...")
+            
             items.extend(new_records["items"])
             pages = new_records["pages"]
 

--- a/backend/connectors/nmbgmr/source.py
+++ b/backend/connectors/nmbgmr/source.py
@@ -45,9 +45,9 @@ from backend.source import (
 )
 
 
-# Set timeout to 30 minutes for analyte and water level requests since some sites have a large number of records and the NMBGMR API can be slow to respond.
+# Set timeout to 15 minutes for analyte and water level requests since some sites have a large number of records and the NMBGMR API can be slow to respond.
 # Don't use timeout=None since that can cause the request to hang indefinitely if there are issues with the API.
-# Instead, catch timeout exceptions and retry the request until it succeeds or a different exception is raised.
+# Instead, catch timeout and other exceptions and retry the request up to 7 times with a delay between retries.
 
 TIMEOUT=15*60
 

--- a/backend/source.py
+++ b/backend/source.py
@@ -19,6 +19,7 @@ import httpx
 import shapely.wkt
 from shapely import MultiPoint
 from typing import Union, List, Callable, Dict
+import time
 
 from backend.constants import (
     FEET,
@@ -200,7 +201,7 @@ class BaseSource(Loggable):
     # Methods Already Implemented
     # ==========================================================================
 
-    def _execute_text_request(self, url: str, params: dict | None = None, **kw) -> str:
+    def _execute_text_request(self, url: str, params: dict | None = None, max_tries: int = 7, **kw) -> str:
         """
         Executes a get request to the provided url and returns the text response.
 
@@ -212,6 +213,9 @@ class BaseSource(Loggable):
         params : dict
             key-value query parameters to pass to the get request
 
+        max_tries : int
+            the maximum number of times to retry the request if it fails
+
         Returns
         -------
         str
@@ -220,17 +224,32 @@ class BaseSource(Loggable):
         if "timeout" not in kw:
             kw["timeout"] = 10
 
-        resp = httpx.get(url, params=params, **kw)
-        if resp.status_code == 200:
-            return resp.text
-        else:
-            self.warn(f"service url {resp.url}")
-            self.warn(f"service responded with status {resp.status_code}")
-            self.warn(f"service responded with text {resp.text}")
+        tries: int = 0
+
+        while tries < max_tries:
+            try:
+                resp = httpx.get(url, params=params, **kw)
+                if resp.status_code == 200:
+                    return resp.text
+                else:
+                    self.warn(f"service responded with status {resp.status_code}")
+                    self.warn(f"service responded with text {resp.text}")
+                    self.warn(f"Retrying... {tries+1}/{max_tries}")
+            except Exception as e:
+                self.warn(f"Error during request: {e}")
+                self.warn(f"Retrying... {tries+1}/{max_tries}")
+            tries += 1
+            time.sleep(tries)
+
             return ""
 
     def _execute_json_request(
-        self, url: str, params: dict | None = None, tag: str | None = None, **kw
+        self,
+        url: str,
+        params: dict | None = None,
+        tag: str | None = None,
+        max_retries: int = 7,
+        **kw
     ) -> dict | None:
         """
         Executes a get request to the provided url and returns the json response.
@@ -245,30 +264,41 @@ class BaseSource(Loggable):
 
         tag : str
             the key to extract from the json response if required
+        
+        max_retries : int
+            the maximum number of times to retry the request if it fails
 
         Returns
         -------
         dict
             the json response
         """
-        resp = httpx.get(url, params=params, **kw)
-        if tag is None:
-            tag = "data"
-
-        if resp.status_code == 200:
+        tries: int = 0
+        while tries < max_retries:
             try:
-                obj = resp.json()
-                if tag and isinstance(obj, dict):
-                    return obj[tag]
-                return obj
-            except JSONDecodeError:
-                self.warn(f"service responded but with no data. \n{resp.text}")
-                return None
-        else:
-            self.warn(f"service responded with status {resp.status_code}")
-            self.warn(f"service responded with text {resp.text}")
-            self.warn(f"service at url:  {resp.url}")
-            return None
+                resp = httpx.get(url, params=params, **kw)
+                if tag is None:
+                    tag = "data"
+
+                if resp.status_code == 200:
+                    try:
+                        obj = resp.json()
+                        if tag and isinstance(obj, dict):
+                            return obj[tag]
+                        return obj
+                    except JSONDecodeError:
+                        self.warn(f"service responded but with no data. \n{resp.text}")
+                        return None
+                else:
+                    self.warn(f"service responded with status {resp.status_code}")
+                    self.warn(f"service responded with text {resp.text}")
+                    self.warn(f"Retrying... {tries+1}/{max_retries}")
+            except Exception as e:
+                self.warn(f"Error during request: {e}")
+                self.warn(f"Retrying... {tries+1}/{max_retries}")
+            tries += 1
+            time.sleep(tries)
+        return None
 
     # ==========================================================================
     # Methods Implemented in BaseSiteSource and BaseParameterSource

--- a/backend/source.py
+++ b/backend/source.py
@@ -234,6 +234,7 @@ class BaseSource(Loggable):
                 else:
                     self.warn(f"service responded with status {resp.status_code}")
                     self.warn(f"service responded with text {resp.text}")
+                    self.warn(f"URL: {url}")
                     self.warn(f"Retrying... {tries+1}/{max_tries}")
             except Exception as e:
                 self.warn(f"Error during request: {e}")
@@ -288,10 +289,12 @@ class BaseSource(Loggable):
                         return obj
                     except JSONDecodeError:
                         self.warn(f"service responded but with no data. \n{resp.text}")
+                        self.warn(f"URL: {url}")
                         return None
                 else:
                     self.warn(f"service responded with status {resp.status_code}")
-                    self.warn(f"service responded with text {resp.text}")
+                    self.warn(f"service responded with text {resp.text} for url {resp.url}")
+                    self.warn(f"URL: {url}")
                     self.warn(f"Retrying... {tries+1}/{max_retries}")
             except Exception as e:
                 self.warn(f"Error during request: {e}")

--- a/backend/source.py
+++ b/backend/source.py
@@ -241,7 +241,7 @@ class BaseSource(Loggable):
             tries += 1
             time.sleep(tries)
 
-            return ""
+        return ""
 
     def _execute_json_request(
         self,


### PR DESCRIPTION
<!--
- Title the PR with the JIRA project & ticket number and short description (e.g., BDMS-123: Example display bug), or NO TICKET
- Keep sections short and scannable.
-->
### **Why**
_This PR addresses the following problem / context:_
- Some sites have many records, causing the server to take too long to respond and therefore raise httpx read timeout errors

### **How**
_Implementation summary - the following was changed / added / removed:_
- Increase the timeout parameter to 15 minutes
- If the request fails for any reason, timeout or otherwise, retry the request up to 7 times

### **Notes**
_Any special considerations, workarounds, or follow-up work to note?_
- The logic for retries was moved to `BaseSource` so it applies everywhere where the `_execute_json_request` and `_execute_text_request` methods are invoked.