### PR TITLE
Add TDS data products: summary + latest value

### DIFF
--- a/orchestration/config/products.yaml
+++ b/orchestration/config/products.yaml
@@ -44,3 +44,25 @@ products:
       state: NM
     sources:
       exclude: []
+
+  - id: nm_tds_summary
+    parameter: tds
+    output_type: ogc_summary
+    title: "NM TDS Summary"
+    description: "TDS concentration summary stats, all NM sources"
+    schedule: "0 10 * * *"
+    spatial_filter:
+      state: NM
+    sources:
+      exclude: []
+
+  - id: nm_tds_latest
+    parameter: tds
+    output_type: ogc_summary
+    title: "NM Latest TDS Value"
+    description: "Most recent TDS value per site, all NM sources"
+    schedule: "0 11 * * *"
+    spatial_filter:
+      state: NM
+    sources:
+      exclude: []


### PR DESCRIPTION
Adds two Dagster+ data products for TDS (all NM sources), via `orchestration/config/products.yaml`:

| id | output_type | description |
|----|-------------|-------------|
| `nm_tds_summary` | `ogc_summary` | TDS concentration summary stats per site |
| `nm_tds_latest` | `ogc_summary` | Most recent TDS value per site |

Both use the `tds` parameter (sources: bor, nmbgmr_amp, nmed_dwb, nmose_isc_seven_rivers, wqp) and materialize through the existing `build_product_assets` graph. The summary GeoJSON already carries `latest_value`/`latest_date` per site, so "latest value" is the same output type with its own id/title.

Verified: `orchestration.definitions` loads — 6 products, 6 schedules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)