### PR TITLE
Remove redundant nm_tds_latest product

### DIFF
--- a/orchestration/config/products.yaml
+++ b/orchestration/config/products.yaml
@@ -55,14 +55,3 @@ products:
       state: NM
     sources:
       exclude: []
-
-  - id: nm_tds_latest
-    parameter: tds
-    output_type: ogc_summary
-    title: "NM Latest TDS Value"
-    description: "Most recent TDS value per site, all NM sources"
-    schedule: "0 11 * * *"
-    spatial_filter:
-      state: NM
-    sources:
-      exclude: []


### PR DESCRIPTION
Follow-up to #73. `nm_tds_latest` was `ogc_summary` over the same `tds` parameter / filter / sources as `nm_tds_summary` — identical GeoJSON, just a different id, running the full unify twice.

The summary output already carries `latest_value` / `latest_date` per site, so the latest TDS value is a field of `nm_tds_summary`, not a separate product. Removing it.

If raw per-observation TDS is wanted later, add `nm_tds_timeseries` (`ogc_timeseries`) — that's the non-redundant counterpart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)