### PR TITLE
Use GCS-backed IO manager for durable asset I/O

### DIFF
--- a/orchestration/definitions.py
+++ b/orchestration/definitions.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 import dagster as dg
 import yaml
+from dagster_gcp.gcs import GCSPickleIOManager, GCSResource as DagsterGCSResource
 
 from orchestration.resources.die_config import DIEConfigResource
 from orchestration.resources.gcs import GCSResource
@@ -59,5 +60,14 @@ defs = dg.Definitions(
             bucket_name=_products_config.get("gcs_bucket", "dataservices-die-products"),
         ),
         "geoserver": GeoServerResource(),
+        # Persist asset I/O to GCS instead of the serverless run's ephemeral
+        # /tmp. Without this, materializing a downstream asset (combine /
+        # geoserver) on its own can't load its source inputs from a prior run
+        # and fails with FileNotFoundError.
+        "io_manager": GCSPickleIOManager(
+            gcs=DagsterGCSResource(),
+            gcs_bucket=_products_config.get("gcs_bucket", "dataservices-die-products"),
+            gcs_prefix="dagster-io",
+        ),
     },
 )


### PR DESCRIPTION
Fixes the runtime failure when a downstream asset is materialized on its own:

```
DagsterExecutionLoadInputError: Error occurred while loading input "src_bor" of step "nm_tds_summary"
FileNotFoundError: .../storage/nm_tds_summary/sources/bor
```

**Cause:** Dagster+ serverless uses the default filesystem IO manager backed by the run's ephemeral `/tmp`. A combine asset (or the geoserver leaf) can only load its source inputs if those source assets ran in the *same* run. Materializing the combine/geoserver asset alone — or relying on a prior run's outputs — can't find them.

**Fix:** configure `GCSPickleIOManager` (prefix `dagster-io` on the existing products bucket) as the default `io_manager`. Asset outputs now persist to GCS, so downstream assets load their inputs across runs.

Scheduled runs (which materialize the full `geoserver.upstream()` graph) already worked; this makes ad-hoc/partial materialization work too and makes outputs durable.

Verified: definitions load — 45 assets, 6 schedules, io_manager = GCSPickleIOManager.

🤖 Generated with [Claude Code](https://claude.com/claude-code)