### PR TITLE
Define an asset job per DIE data product

### DIFF
--- a/orchestration/definitions.py
+++ b/orchestration/definitions.py
@@ -26,20 +26,40 @@ def _build_assets(products_config: dict) -> list:
     return assets
 
 
-def _build_schedules(products_config: dict) -> list:
-    schedules = []
+def _product_selection(pid: str) -> dg.AssetSelection:
+    # The full per-product graph: the geoserver leaf plus everything upstream of
+    # it (combine asset + source assets).
+    return dg.AssetSelection.keys(dg.AssetKey([pid, "geoserver"])).upstream()
+
+
+def _products(products_config: dict):
     for product in products_config["products"]:
-        if product.get("output_type") not in _SUPPORTED_OUTPUT_TYPES:
-            continue
+        if product.get("output_type") in _SUPPORTED_OUTPUT_TYPES:
+            yield product
+
+
+def _build_jobs(products_config: dict) -> dict:
+    """One asset job per product, selecting that product's whole graph.
+    Returns {product_id: job} so schedules can target the job."""
+    jobs = {}
+    for product in _products(products_config):
+        pid = product["id"]
+        jobs[pid] = dg.define_asset_job(
+            name=f"{pid}_job",
+            selection=_product_selection(pid),
+            description=f"Materialize the {pid} data product (sources → combine → geoserver).",
+        )
+    return jobs
+
+
+def _build_schedules(products_config: dict, jobs: dict) -> list:
+    schedules = []
+    for product in _products(products_config):
         pid = product["id"]
         schedules.append(
             dg.ScheduleDefinition(
                 name=f"schedule_{pid}",
-                # Materialize the full per-product graph: the geoserver leaf plus
-                # everything upstream of it (combine asset + source assets).
-                target=dg.AssetSelection.keys(
-                    dg.AssetKey([pid, "geoserver"])
-                ).upstream(),
+                job=jobs[pid],
                 cron_schedule=product.get("schedule", "0 6 * * *"),
                 execution_timezone="America/Denver",
             )
@@ -49,10 +69,12 @@ def _build_schedules(products_config: dict) -> list:
 
 _products_config = _load_products()
 _assets = _build_assets(_products_config)
-_schedules = _build_schedules(_products_config)
+_jobs = _build_jobs(_products_config)
+_schedules = _build_schedules(_products_config, _jobs)
 
 defs = dg.Definitions(
     assets=_assets,
+    jobs=list(_jobs.values()),
     schedules=_schedules,
     resources={
         "die_config": DIEConfigResource(),


### PR DESCRIPTION
## What

Adds a named Dagster asset job for each DIE data product — `{product_id}_job` — selecting that product's full graph (source assets → combine → geoserver). Schedules now target these jobs instead of raw asset selections.

## Why

Previously each product's schedule pointed at an ad-hoc `AssetSelection`. There was no first-class, launchable unit for "materialize this product." With explicit jobs:
- Each product is runnable on demand from the Dagster UI **Jobs** tab.
- Scheduled runs and manual runs share one selection definition (no drift).
- Runs get a stable, product-named identity.

## Changes

- `orchestration/definitions.py`:
  - `_product_selection(pid)` — the per-product graph (geoserver leaf + everything upstream).
  - `_build_jobs()` — one `define_asset_job` per product, returned as `{product_id: job}`.
  - `_build_schedules()` now binds each `ScheduleDefinition` to its job (`job=`).
  - Jobs registered in `Definitions(jobs=...)`.

## Notes for reviewer

- No behavior change to what gets materialized — same per-product graph, now wrapped in a job.
- 5 jobs created (arsenic, tds, waterlevels summary/timeseries, bernco waterlevels timeseries); verified each job resolves to its full source→combine→geoserver chain and schedules bind cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)