### PR TITLE
Bump base Python to 3.14

### DIFF
--- a/.github/workflows/branch_deployments.yml
+++ b/.github/workflows/branch_deployments.yml
@@ -11,7 +11,7 @@ env:
   DAGSTER_CLOUD_URL: "http://nmbgmr-data-services.dagster.plus"
   DAGSTER_CLOUD_API_TOKEN: ${{ secrets.DAGSTER_CLOUD_API_TOKEN }}
   ENABLE_FAST_DEPLOYS: 'true'
-  PYTHON_VERSION: '3.10'
+  PYTHON_VERSION: '3.14'
   DAGSTER_CLOUD_FILE: 'dagster_cloud.yaml'
 
 jobs:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -22,7 +22,7 @@ jobs:
         version: "latest"
 
     - name: Set up Python
-      run: uv python install 3.10
+      run: uv python install 3.14
 
     - name: Install dependencies
       run: uv sync --extra dev

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ env:
   DAGSTER_CLOUD_URL: "http://nmbgmr-data-services.dagster.plus"
   DAGSTER_CLOUD_API_TOKEN: ${{ secrets.DAGSTER_CLOUD_API_TOKEN }}
   ENABLE_FAST_DEPLOYS: 'true'
-  PYTHON_VERSION: '3.10'
+  PYTHON_VERSION: '3.14'
   DAGSTER_CLOUD_FILE: 'dagster_cloud.yaml'
 
 jobs:

--- a/.github/workflows/orchestration-ci.yml
+++ b/.github/workflows/orchestration-ci.yml
@@ -26,7 +26,7 @@ jobs:
         version: "latest"
 
     - name: Set up Python
-      run: uv python install 3.10
+      run: uv python install 3.14
 
     - name: Install root package deps
       run: uv sync --extra dev

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -18,10 +18,10 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@master
-      - name: Set up Python 3.13
+      - name: Set up Python 3.14
         uses: actions/setup-python@v5
         with:
-          python-version: 3.13
+          python-version: 3.14
 
       - name: Install pypa/build
         run: >-

--- a/orchestration/Dockerfile
+++ b/orchestration/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim
+FROM python:3.14-slim
 
 WORKDIR /app
 

--- a/orchestration/pyproject.toml
+++ b/orchestration/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "die-orchestration"
 version = "0.1.0"
 description = "DIE Dagster orchestration (internal, not published)"
-requires-python = ">=3.10"
+requires-python = ">=3.14"
 dependencies = [
     "dagster>=1.8",
     "dagster-cloud",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "New Mexico Water Data Integration Engine"
 readme = "README.md"
 license = { text = "Apache-2.0" }
 authors = [{ name = "Jake Ross" }]
-requires-python = ">=3.10"
+requires-python = ">=3.14"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Operating System :: OS Independent",


### PR DESCRIPTION
## What

Raise the base Python version to **3.14** across the repo.

## Changes

- `pyproject.toml` + `orchestration/pyproject.toml`: `requires-python = ">=3.14"`.
- `.github/workflows/cicd.yml`, `orchestration-ci.yml`: `uv python install 3.14`.
- `.github/workflows/branch_deployments.yml`, `deploy.yml`: `PYTHON_VERSION: '3.14'` (also feeds the Dagster+ serverless `base_image: python:3.14-slim`).
- `.github/workflows/publish-to-pypi.yml`: setup-python `3.14`.
- `orchestration/Dockerfile`: `FROM python:3.14-slim`.

## Verification

- Full orchestration stack resolves, builds, and imports on **3.14.5** (129 packages incl. dagster, geopandas, shapely, pyogrio, pyarrow, grpcio — all have 3.14 wheels or build clean).
- Backend tests pass: **261 passed** on 3.14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)