### PR TITLE
Make Record pickle-safe (fix RecursionError via GCS IO manager)

### DIFF
--- a/backend/record.py
+++ b/backend/record.py
@@ -79,7 +79,17 @@ class BaseRecord:
         return v
 
     def __getattr__(self, attr):
-        v = self._payload.get(attr)
+        # Guard against recursion when the instance has no _payload yet — e.g.
+        # during unpickling, when pickle probes getattr(obj, "__setstate__")
+        # before __dict__ is restored. Reading via __dict__ (not self._payload)
+        # avoids re-entering __getattr__, and dunder lookups raise cleanly so
+        # pickle falls back to its default state restore.
+        if attr.startswith("__") and attr.endswith("__"):
+            raise AttributeError(attr)
+        payload = self.__dict__.get("_payload")
+        if payload is None:
+            raise AttributeError(attr)
+        v = payload.get(attr)
         if v is None and self.defaults:
             v = self.defaults.get(attr)
         return v


### PR DESCRIPTION
## Problem

Materializing a downstream asset (e.g. `nm_waterlevel_trends`) fails loading an upstream input:

```
RecursionError: maximum recursion depth exceeded
  backend/record.py, line 82, in __getattr__
    v = self._payload.get(attr)   [repeated 980+ times]
```

`Record.__getattr__` reads `self._payload`. During **unpickling** (the GCS pickle IO manager passing data between assets), pickle probes `getattr(obj, "__setstate__")` *before* `__dict__` is restored, so `_payload` doesn't exist yet → `__getattr__` recurses on `__getattr__('_payload')` until it blows the stack. Triggers whenever a `Record` — or a payload dict nesting one — crosses between assets.

## Fix

Guard `__getattr__`:
- dunder lookups raise `AttributeError` (so pickle falls back to its default state restore);
- `_payload` is read via `self.__dict__.get("_payload")`, which can't re-enter `__getattr__`.

## Verification

- Bare and nested `Record`s now round-trip through `pickle.dumps`/`loads`.
- Full backend suite passes (263 tests).

## Note

This was committed to the #84 branch after that PR was squash-merged, so it didn't reach `main`. Standalone fix here — affects every IO-manager product (major-chemistry, waterlevel-trends, etc.), so worth merging promptly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)