### PR TITLE
Scope bernco product statewide to dedupe its source fetch

### DIFF
--- a/orchestration/config/products.yaml
+++ b/orchestration/config/products.yaml
@@ -23,6 +23,12 @@ products:
     sources:
       exclude: []
 
+  # The bernco source (BernCoWaterLevelSource) is county-scoped by construction —
+  # all its wells are in Bernalillo — so a county filter is a no-op here. Using
+  # the state_NM scope (with include:[bernco]) yields identical output while
+  # sharing the statewide bernco source asset, so bernco unifies once instead of
+  # twice. (A county filter would only matter if the source returned wells
+  # outside Bernalillo, which it does not.)
   - id: bernco_waterlevels_timeseries
     parameter: waterlevels
     output_type: ogc_timeseries
@@ -30,7 +36,7 @@ products:
     description: "Bernalillo County water level timeseries per well"
     schedule: "0 8 * * *"
     spatial_filter:
-      county: Bernalillo
+      state: NM
     sources:
       include: [bernco]
 


### PR DESCRIPTION
Follow-up to the cohort-jobs change (#93). The bernco source (`BernCoWaterLevelSource`) is county-scoped by construction — all its wells are in Bernalillo — so the `county_Bernalillo` filter on `bernco_waterlevels_timeseries` was a no-op.

Switching that product to `state_NM` scope (keeping `include: [bernco]`) yields identical output but lets it **share the statewide bernco source asset** instead of unifying bernco a second time under its own scope.

Effect:
- bernco unifies once; source assets 87 → 86.
- Removes the singleton Bernalillo cohort — `bernco_waterlevels_timeseries` joins the `waterlevels_timeseries_state_NM` cohort; cohort jobs 5 → 4.

Caveat: the county filter was a cheap guard against a stray out-of-county well; removing it trusts the source's construction (low risk — it's county-scoped).

`dg check defs` clean; 277 offline tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)