### PR TITLE
Remove the Bernalillo-County-only water-level timeseries product

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -235,17 +235,6 @@ products:
     sources:
       exclude: []
 
-  - id: bernco_waterlevels_timeseries
-    parameter: waterlevels
-    output_type: ogc_timeseries
-    title: "Bernalillo County Water Level Time Series"
-    description: "Bernalillo County water level timeseries per well"
-    schedule: "0 8 * * *"
-    spatial_filter:
-      county: Bernalillo
-    sources:
-      include: [bernco]
-
   - id: nm_arsenic_summary
     parameter: arsenic
     output_type: ogc_summary

--- a/orchestration/config/products.yaml
+++ b/orchestration/config/products.yaml
@@ -23,23 +23,6 @@ products:
     sources:
       exclude: []
 
-  # The bernco source (BernCoWaterLevelSource) is county-scoped by construction —
-  # all its wells are in Bernalillo — so a county filter is a no-op here. Using
-  # the state_NM scope (with include:[bernco]) yields identical output while
-  # sharing the statewide bernco source asset, so bernco unifies once instead of
-  # twice. (A county filter would only matter if the source returned wells
-  # outside Bernalillo, which it does not.)
-  - id: bernco_waterlevels_timeseries
-    parameter: waterlevels
-    output_type: ogc_timeseries
-    title: "Bernalillo County Water Level Time Series"
-    description: "Bernalillo County water level timeseries per well"
-    schedule: "0 8 * * *"
-    spatial_filter:
-      state: NM
-    sources:
-      include: [bernco]
-
   - id: nm_arsenic_summary
     parameter: arsenic
     output_type: ogc_summary


### PR DESCRIPTION
Drops the `bernco_waterlevels_timeseries` product — a Bernalillo-County-scoped subset of the water-level timeseries that is no longer a wanted deliverable.

- **No data lost:** `nm_waterlevels_timeseries` (all NM sources) already includes bernco wells; only the county-scoped layer is removed.
- **bernco source unchanged:** its shared source asset stays — still consumed by `nm_waterlevels_timeseries`, `nm_waterlevel_trends`, `nm_monitoring_recency`, and the summary. Only this product's combine + geoserver assets and its schedule go away.
- Also removes the product from the SPEC.md `products.yaml` example.

`dg check defs` clean.

Note: existing published artifacts (the GeoServer layer and GCS objects for `bernco_waterlevels_timeseries`) are **not** auto-deleted by this change — remove them manually if you want the old layer gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)