### PR TITLE
Derive PARAMETER_SOURCE_MAP waterlevels list from the registry (3.3)

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -76,32 +76,6 @@ from .connectors.wqp.source import WQPSiteSource, WQPAnalyteSource, WQPWaterLeve
 from backend.logger import make_logger
 
 
-# Which sources report each parameter (empirical availability). A plain
-# parameter -> [source_key, ...] map; the waterlevels list mirrors the sources
-# with a waterlevel class in the SOURCES registry (asserted by
-# tests/test_source_registry.py), while the analyte lists are authored because
-# they encode which analytes each agency actually reports.
-PARAMETER_SOURCE_MAP = {
-    WATERLEVELS: ["bernco", "cabq", "ebid", "nmbgmr_amp", "nmose_isc_seven_rivers", "nmose_roswell", "nwis", "pvacd", "wqp"],
-    CARBONATE: ["nmbgmr_amp", "wqp"],
-    ARSENIC: ["bor", "nmbgmr_amp", "nmed_dwb", "wqp"],
-    URANIUM: ["bor", "nmbgmr_amp", "nmed_dwb", "wqp"],
-    SPECIFIC_CONDUCTANCE: ["nmbgmr_amp", "nmed_dwb", "nmose_isc_seven_rivers", "wqp"],
-    CONDUCTIVITY: ["bor", "nmose_isc_seven_rivers", "wqp"],
-    BICARBONATE: ["nmbgmr_amp", "nmed_dwb", "nmose_isc_seven_rivers", "wqp"],
-    CALCIUM: ["bor", "nmbgmr_amp", "nmed_dwb", "nmose_isc_seven_rivers", "wqp"],
-    CHLORIDE: ["bor", "nmbgmr_amp", "nmed_dwb", "nmose_isc_seven_rivers", "wqp"],
-    FLUORIDE: ["bor", "nmbgmr_amp", "nmed_dwb", "nmose_isc_seven_rivers", "wqp"],
-    MAGNESIUM: ["bor", "nmbgmr_amp", "nmed_dwb", "nmose_isc_seven_rivers", "wqp"],
-    NITRATE: ["bor", "nmbgmr_amp", "nmed_dwb", "nmose_isc_seven_rivers", "wqp"],
-    PH: ["bor", "nmbgmr_amp", "nmed_dwb", "nmose_isc_seven_rivers", "wqp"],
-    POTASSIUM: ["bor", "nmbgmr_amp", "nmed_dwb", "nmose_isc_seven_rivers", "wqp"],
-    SILICA: ["bor", "nmbgmr_amp", "nmed_dwb", "nmose_isc_seven_rivers", "wqp"],
-    SODIUM: ["bor", "nmbgmr_amp", "nmed_dwb", "nmose_isc_seven_rivers", "wqp"],
-    SULFATE: ["bor", "nmbgmr_amp", "nmed_dwb", "nmose_isc_seven_rivers", "wqp"],
-    TDS: ["bor", "nmbgmr_amp", "nmed_dwb", "nmose_isc_seven_rivers", "wqp"],
-}
-
 @dataclass(frozen=True)
 class SourceDef:
     """One data source's class wiring, declared in a single place.
@@ -158,6 +132,33 @@ ANALYTE_SOURCE_PAIRS = {
 }
 WATERLEVEL_SOURCE_PAIRS = {
     s.key: (s.site, s.waterlevel) for s in SOURCES if s.waterlevel is not None
+}
+
+# Which sources report each parameter (empirical availability), parameter ->
+# [source_key, ...]. The waterlevels list is DERIVED from the registry (every
+# source with a waterlevel class). The analyte lists are authored because they
+# encode which analytes each agency actually reports — which can't be inferred
+# from the class wiring. tests/test_source_registry.py guards both against the
+# registry.
+PARAMETER_SOURCE_MAP = {
+    WATERLEVELS: [s.key for s in SOURCES if s.waterlevel is not None],
+    CARBONATE: ["nmbgmr_amp", "wqp"],
+    ARSENIC: ["bor", "nmbgmr_amp", "nmed_dwb", "wqp"],
+    URANIUM: ["bor", "nmbgmr_amp", "nmed_dwb", "wqp"],
+    SPECIFIC_CONDUCTANCE: ["nmbgmr_amp", "nmed_dwb", "nmose_isc_seven_rivers", "wqp"],
+    CONDUCTIVITY: ["bor", "nmose_isc_seven_rivers", "wqp"],
+    BICARBONATE: ["nmbgmr_amp", "nmed_dwb", "nmose_isc_seven_rivers", "wqp"],
+    CALCIUM: ["bor", "nmbgmr_amp", "nmed_dwb", "nmose_isc_seven_rivers", "wqp"],
+    CHLORIDE: ["bor", "nmbgmr_amp", "nmed_dwb", "nmose_isc_seven_rivers", "wqp"],
+    FLUORIDE: ["bor", "nmbgmr_amp", "nmed_dwb", "nmose_isc_seven_rivers", "wqp"],
+    MAGNESIUM: ["bor", "nmbgmr_amp", "nmed_dwb", "nmose_isc_seven_rivers", "wqp"],
+    NITRATE: ["bor", "nmbgmr_amp", "nmed_dwb", "nmose_isc_seven_rivers", "wqp"],
+    PH: ["bor", "nmbgmr_amp", "nmed_dwb", "nmose_isc_seven_rivers", "wqp"],
+    POTASSIUM: ["bor", "nmbgmr_amp", "nmed_dwb", "nmose_isc_seven_rivers", "wqp"],
+    SILICA: ["bor", "nmbgmr_amp", "nmed_dwb", "nmose_isc_seven_rivers", "wqp"],
+    SODIUM: ["bor", "nmbgmr_amp", "nmed_dwb", "nmose_isc_seven_rivers", "wqp"],
+    SULFATE: ["bor", "nmbgmr_amp", "nmed_dwb", "nmose_isc_seven_rivers", "wqp"],
+    TDS: ["bor", "nmbgmr_amp", "nmed_dwb", "nmose_isc_seven_rivers", "wqp"],
 }
 
 

--- a/docs/cleanup-todo.md
+++ b/docs/cleanup-todo.md
@@ -1,7 +1,8 @@
 # DIE Cleanup TODO
 
-> **Status:** Tier 1 (all) and **all of Tier 2 except 2.6** are **DONE**. 2.6 is
-> **deferred** (see note below). Remaining: 2.6, all of Tier 3, all of Tier 4.
+> **Status:** Tier 1 (all), all of Tier 2 except 2.6, and Tier 3 item 3.3 are
+> **DONE**. 2.6 is **deferred** (see note). Remaining: 2.6, Tier 3 items 3.1/3.2,
+> all of Tier 4.
 
 Prioritized cleanup backlog from a code-analysis sweep (backend + frontend +
 orchestration). Each item: location, effort (S/M/L), risk, and whether it
@@ -50,7 +51,7 @@ registry). Tiers are ordered by safety — Tier 1 is batchable into one no-risk 
 |---|----------|--------|--------|---|
 | 3.1 | `frontend/cli.py:36-121` (`--no-X` flags) + `cli.py:385-398` (hardcoded agency list in `sites()`) | Derive from `backend.config.SOURCE_KEYS` — the remaining hardcoded source list after #101/#102. Click flags are harder to generate dynamically; at minimum dedup the `sites()` list. | M | ✓ |
 | 3.2 | `orchestration/definitions.py:60-68` (`_SUPPORTED_OUTPUT_TYPES`) vs `products.py` combine `if/elif` chain | Single registry mapping `output_type → (dumper, is_summary)`; both the supported-set and the dispatch derive from it. Adding an output type → one entry. | M | |
-| 3.3 | `backend/config.py:79` `PARAMETER_SOURCE_MAP[WATERLEVELS]` | Derive the waterlevels agency list from the `SOURCES` registry (== sources with a waterlevel class; the desync test already asserts equality). Keep analyte entries authored. | S | ✓ |
+| 3.3 ✅ | `backend/config.py` `PARAMETER_SOURCE_MAP[WATERLEVELS]` | Derived from the `SOURCES` registry (`[s.key for s in SOURCES if s.waterlevel]`). Analyte entries stay authored. Map moved below the registry so it can reference `SOURCES`. | S | ✓ |
 
 ---
 


### PR DESCRIPTION
Tier 3 item **3.3** from `docs/cleanup-todo.md`. **Stacked on #104** (base `chore/cleanup-tier2`). Merge order: #101 → #102 → #103 → #104 → this.

The `WATERLEVELS` entry of `PARAMETER_SOURCE_MAP` duplicated what the `SOURCES` registry already encodes — the sources with a waterlevel class. It's now derived:

```python
WATERLEVELS: [s.key for s in SOURCES if s.waterlevel is not None],
```

`PARAMETER_SOURCE_MAP` moved below the registry so it can reference `SOURCES`. Analyte entries stay **authored** — they encode which analytes each agency actually reports, which can't be inferred from class wiring.

The derived list is identical (including order) to the previous hardcoded one; `tests/test_source_registry.py` still guards the registry↔map relationship.

No behavior change. Full suite **311 passed**; `dg check defs` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)