### PR TITLE
Coerce MCL exceedance value to float before comparison

### DIFF
--- a/backend/persisters/ogc_features.py
+++ b/backend/persisters/ogc_features.py
@@ -418,7 +418,8 @@ def dump_mcl_exceedance_collection(
             # larger). If the data basis is NO3, this flag is wrong unless the
             # mcl in config/mcl.json is the as-NO3 value (~44.3 mg/L). Confirm
             # DIE's normalized nitrate basis before trusting nitrate exceedances.
-            exceeds = value is not None and mcl is not None and value > mcl
+            num = _num(value)
+            exceeds = num is not None and mcl is not None and num > mcl
             props[f"{analyte}_exceeds"] = exceeds
             if exceeds:
                 exceeded.append(analyte)


### PR DESCRIPTION
## What

In `dump_mcl_exceedance_collection` (`backend/persisters/ogc_features.py`), the exceedance flag compared the raw `latest_value` directly against the float `mcl`:

```python
exceeds = value is not None and mcl is not None and value > mcl
```

`latest_value` can arrive as a `str` from some sources, so `value > mcl` raised:

```
TypeError: '>' not supported between instances of 'str' and 'float'
```

which surfaced as a Dagster step failure on the `nm_mcl_exceedance` op.

## Fix

Coerce the value through the existing `_num()` helper before comparing:

```python
num = _num(value)
exceeds = num is not None and mcl is not None and num > mcl
```

Unparseable / missing values become `None` → no exceedance flag, matching prior missing-value behavior.

## Notes for reviewer

- Reuses the existing `_num()` helper (same module) rather than adding a new one.
- No change to stored `props[analyte]` (still the original value); only the comparison is hardened.