### PR TITLE
Remove deprecated source shims (transformer_klass, validator override)

### DIFF
--- a/backend/source.py
+++ b/backend/source.py
@@ -69,18 +69,6 @@ class WaterLevelRecordValidator(RecordValidator):
                 raise ValueError(f"Invalid record. Missing {k}")
 
 
-class _SubclassValidatorShim(RecordValidator):
-    """Shim: delegates to source._validate_record() for subclasses that override it."""
-    def __init__(self, source):
-        self._source = source
-
-    def set_config(self, config) -> None:
-        pass  # source._validate_record uses self.config directly
-
-    def validate(self, record: dict) -> None:
-        self._source._validate_record(record)
-
-
 # =============================================================================
 # Record summarization strategy
 # =============================================================================
@@ -192,10 +180,8 @@ _FETCH_UNSET = object()  # sentinel: site fetch not yet cached
 
 
 class BaseSource:
-    transformer_klass = BaseTransformer  # deprecated: pass transformer= to __init__
-
     def __init__(self, transformer: Optional[BaseTransformer] = None, http_client: httpx.Client | None = None):
-        self.transformer = transformer if transformer is not None else self.transformer_klass()
+        self.transformer = transformer if transformer is not None else BaseTransformer()
         self._http_client = http_client if http_client is not None else httpx.Client(timeout=900)
         _l = make_logger(self.__class__.__name__)
         self.log = _l.log
@@ -228,7 +214,7 @@ class BaseSource:
     def set_config(self, config):
         self.config = config
         self.transformer.set_config(config)
-        if hasattr(self, "_validator"):
+        if getattr(self, "_validator", None) is not None:
             self._validator.set_config(config)
 
     def check(self, *args, **kw):
@@ -356,7 +342,7 @@ class BaseParameterSource(BaseSource):
 
     def __init__(self, transformer=None, validator: Optional[RecordValidator] = None, http_client: httpx.Client | None = None):
         super().__init__(transformer=transformer, http_client=http_client)
-        self._validator = validator if validator is not None else _SubclassValidatorShim(self)
+        self._validator = validator
         self._summarizer = RecordSummarizer(self)
 
     def _extract_earliest_record(self, records: list) -> dict:
@@ -483,15 +469,12 @@ class BaseParameterSource(BaseSource):
 
     def _extract_parameter(self, record: dict) -> dict:
         record = self._extract_parameter_record(record)
-        self._validator.validate(record)
+        if self._validator is not None:
+            self._validator.validate(record)
         return record
 
     def _sort_func(self, x):
         return x.date_measured
-
-    # deprecated: override via validator= __init__ arg instead
-    def _validate_record(self, record: dict) -> None:
-        raise NotImplementedError(f"{self.__class__.__name__} Must implement _validate_record")
 
 
 class BaseAnalyteSource(BaseParameterSource):

--- a/docs/cleanup-todo.md
+++ b/docs/cleanup-todo.md
@@ -62,7 +62,7 @@ registry). Tiers are ordered by safety — Tier 1 is batchable into one no-risk 
 - **`config.validate()` `sys.exit(2)` → raise** — library code shouldn't exit the process; raise a `ConfigError` and let CLI translate to an exit code. (Affects callers; needs care.)
 - **Hoist connector `_extract_*` duplication** — `_extract_source_parameter_results/dates/units` repeat dict/list access across connectors; lift common shapes to a base.
 - **Spatial-filter precedence** — `bbox_bounding_points` (bbox first) vs `bounding_wkt` (wkt first) resolve multiple filters differently; #101 warns, but unify the precedence. Consider a small `Scope` value object and drop the `wkt=None`-means-statewide magic in `die_config`.
-- **Remove deprecated shims** — `transformer_klass`, `_SubclassValidatorShim`, `_validate_record` (`backend/source.py`). Verify no connector still relies on the override path first.
+- ✅ **Remove deprecated shims** (DONE) — removed `transformer_klass`, `_SubclassValidatorShim`, `_validate_record` (`backend/source.py`). Verified no connector overrides `_validate_record` or sets `transformer_klass`, and every concrete parameter source gets a real validator via `BaseAnalyteSource`/`BaseWaterLevelSource` (WQP through its mixin MRO). `transformer=None` now falls back to `BaseTransformer()` directly; `validator=None` is tolerated (validation skipped) for the test fake / mixin.
 
 ---
 


### PR DESCRIPTION
Tier 4 **"remove deprecated shims"** from `docs/cleanup-todo.md`. **Stacked on #105** (base `chore/cleanup-3-3`). Merge order: #101 → #102 → #103 → #104 → #105 → this.

Removes three dead back-compat paths in `backend/source.py`:

| Removed | Why it's dead |
|---|---|
| `BaseSource.transformer_klass` | No source overrides it; every connector passes `transformer=`. The `transformer=None` fallback now builds `BaseTransformer()` directly. |
| `_SubclassValidatorShim` | Default validator only when `validator=None`. It delegated to `_validate_record`, which **nothing overrides**. |
| `BaseParameterSource._validate_record` (stub) | The override hook the shim targeted — unused. |

**Verified safe before removing:**
- No connector sets `transformer_klass` or overrides `_validate_record` (grep across `backend/`).
- Every concrete parameter source gets a **real** validator (`AnalyteRecordValidator`/`WaterLevelRecordValidator`) via `BaseAnalyteSource`/`BaseWaterLevelSource`. `WQPParameterSource` is a mixin (no `__init__`); `WQPAnalyteSource(WQPParameterSource, BaseAnalyteSource)` reaches the real validator through MRO.
- The only `validator=None` cases (the test fake, the uninstantiated mixin) never validate; `_extract_parameter` now skips validation when `_validator is None`, and `set_config` guards it.

No behavior change. Full suite **311 passed**; `dg check defs` clean; no dangling references to the removed symbols.

🤖 Generated with [Claude Code](https://claude.com/claude-code)