### PR TITLE
Fix county-mode bbox crash in bbox_bounding_points

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -328,7 +328,7 @@ class Config:
         if bbox is None:
             bbox = self.bbox
 
-        if isinstance(bbox, str):
+        if isinstance(bbox, str) and bbox.strip():
             p1, p2 = bbox.split(",")
             x1, y1 = [float(a) for a in p1.strip().split(" ")]
             x2, y2 = [float(a) for a in p2.strip().split(" ")]


### PR DESCRIPTION
An empty bbox string (the default when scoping by county) hit the str branch and raised ValueError on "".split(","), so WQP and NWIS silently returned no sites for any county-scoped run. Guard the str branch on a non-empty value so an empty bbox falls through to deriving bounds from the county/wkt polygon.

<!--
- Title the PR with the JIRA project & ticket number and short description (e.g., BDMS-123: Example display bug), or NO TICKET
- Keep sections short and scannable.
-->
### **Why**
_This PR addresses the following problem / context:_
- Use bullet points here

### **How**
_Implementation summary - the following was changed / added / removed:_
- Use bullet points here

### **Notes**
_Any special considerations, workarounds, or follow-up work to note?_
- Use bullet points here
