### PR TITLE
Fix Python 2 except syntax breaking Python 3 parse

### DIFF
--- a/backend/persisters/ogc_features.py
+++ b/backend/persisters/ogc_features.py
@@ -136,7 +136,7 @@ def _num(value) -> Optional[float]:
         return None
     try:
         return float(value)
-    except TypeError, ValueError:
+    except (TypeError, ValueError):
         return None
 
 

--- a/backend/unifier.py
+++ b/backend/unifier.py
@@ -148,7 +148,7 @@ def _site_wrapper(site_source, parameter_source, persister, config, raise_errors
 
         try:
             sites = site_source.read()
-        except USGSRateLimitError, PartialOrNoDataError:
+        except (USGSRateLimitError, PartialOrNoDataError):
             config.warn(incomplete_sites_record_msg)
             sites = []
 

--- a/backend/well_correlation.py
+++ b/backend/well_correlation.py
@@ -112,7 +112,7 @@ def _num(value: Any) -> Optional[float]:
         return None
     try:
         return float(value)
-    except TypeError, ValueError:
+    except (TypeError, ValueError):
         return None
 
 


### PR DESCRIPTION
## Problem

Three Python-2-style `except A, B:` clauses are `SyntaxError` under Python 3, introduced by 545d3ab ("Dedup connectors and cut pipeline compute time"). They break import/collection of core modules (`backend/unifier.py` won't parse), failing CI for every branch and the whole backend test suite.

## Fix

Parenthesize each exception tuple:

1. `backend/unifier.py:151` — `except USGSRateLimitError, PartialOrNoDataError:` → `except (USGSRateLimitError, PartialOrNoDataError):`
2. `backend/persisters/ogc_features.py:139` — `except TypeError, ValueError:` → `except (TypeError, ValueError):`
3. `backend/well_correlation.py:115` — `except TypeError, ValueError:` → `except (TypeError, ValueError):`

## Verification

- `python -m py_compile` passes on all three files
- `python -c "import backend.unifier"` succeeds in the `.venv`

Should merge before #112/#113 so their CI can pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)