### PR TITLE
Dedup NWIS site time-series features by location

### DIFF
--- a/backend/connectors/usgs/source.py
+++ b/backend/connectors/usgs/source.py
@@ -186,7 +186,28 @@ class NWISSiteSource(BaseSiteSource):
         records: list = data.get("features", [])
         self._requester.check_truncation(data, "site")
 
-        return records
+        # combined-metadata returns one feature per time series (data_type /
+        # statistic), so a location with multiple series (e.g. field
+        # measurements + daily mean/max/min) appears several times with the
+        # same monitoring_location_id and identical site metadata. Left as-is,
+        # read_timeseries iterates each duplicate site and re-emits that well's
+        # readings once per series, producing exact-duplicate observations
+        # downstream. Keep the first feature per location; readings come only
+        # from the field-measurements collection regardless of series.
+        deduped: list = []
+        seen: set = set()
+        for feature in records:
+            site_id = feature.get("properties", {}).get("monitoring_location_id")
+            if site_id in seen:
+                continue
+            seen.add(site_id)
+            deduped.append(feature)
+
+        removed = len(records) - len(deduped)
+        if removed:
+            self.warn(f"Dropped {removed} duplicate site time-series features ({len(deduped)} unique locations)")
+
+        return deduped
 
 
 class NWISWaterLevelSource(BaseWaterLevelSource):

--- a/tests/test_sources/test_nwis.py
+++ b/tests/test_sources/test_nwis.py
@@ -23,3 +23,39 @@ class TestNWISWaterlevels(BaseSourceTestClass):
     parameter = WATERLEVELS
     units = FEET
     agency = "nwis"
+
+
+def _site_feature(loc_id, data_type):
+    return {
+        "properties": {
+            "monitoring_location_id": loc_id,
+            "data_type": data_type,
+            "monitoring_location_name": "TOME SITE",
+        },
+        "geometry": {"type": "Point", "coordinates": [-106.6, 34.7]},
+    }
+
+
+def test_nwis_site_source_dedups_duplicate_timeseries_features():
+    # combined-metadata returns one feature per time series, so a well with
+    # several series (field measurements + daily mean/max/min) shows up multiple
+    # times with the same monitoring_location_id. get_records must collapse these
+    # to one site so its readings aren't re-emitted once per series downstream.
+    from backend.config import Config
+    from backend.connectors.usgs.source import NWISSiteSource
+
+    features = [
+        _site_feature("USGS-344431106393403", "Field measurements"),
+        _site_feature("USGS-344431106393403", "Daily values"),
+        _site_feature("USGS-344431106393403", "Continuous values"),
+        _site_feature("USGS-999900000000000", "Field measurements"),
+    ]
+
+    source = NWISSiteSource()
+    source.set_config(Config())
+    source._requester.request = lambda *a, **k: {"features": features, "links": []}
+
+    records = source.get_records()
+
+    ids = [f["properties"]["monitoring_location_id"] for f in records]
+    assert ids == ["USGS-344431106393403", "USGS-999900000000000"]


### PR DESCRIPTION
## Problem

`nm_waterlevels_timeseries` had exact-duplicate observations. Well `USGS-344431106393403` (06N.03E.18.442B TOME SITE): 166 real quarterly readings, but ~840 rows returned (~5×, same datetime + value + everything).

## Root cause

Source is **NWIS**. The `combined-metadata` endpoint returns **one feature per time series**, not per well. TOME has 5 series for parameter 72019 (Field measurements, Continuous, Daily Mean/Max/Min) → 5 identical site features with the same `monitoring_location_id` and identical geometry/metadata.

`NWISSiteSource.get_records` returned all 5 → 5 `SiteRecord`s with the same id → `read_timeseries` iterated each and re-emitted that well's field-measurement readings once per series → 5×169 ≈ 840 dup rows downstream.

Verified live against the USGS API: **448 NM groundwater locations** are duplicated this way (some up to 6×). Confirmed NWIS `field-measurements` (169 distinct, no dup), NMBGMR, and WQP fetches are all clean — the duplication is purely the site list.

## Fix

Dedup site features by `monitoring_location_id` in `NWISSiteSource.get_records`, keeping the first. Readings come only from the `field-measurements` collection regardless of which series listed the well, so dropping the extra metadata rows is safe. Warns with the drop count.

Fixes every affected NM well, not just TOME.

## Test

Added `test_nwis_site_source_dedups_duplicate_timeseries_features` (mocks the requester, no live API) — passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)