### PR TITLE
Harden Parquet IO against mixed-type parameter_value columns

### DIFF
--- a/backend/persisters/geodataframe.py
+++ b/backend/persisters/geodataframe.py
@@ -196,13 +196,38 @@ def _clean_nans(records: list[dict]) -> list[dict]:
     return [{k: (None if pd.isna(v) else v) for k, v in row.items()} for row in records]
 
 
+def _frame_to_parquet_bytes(df: pd.DataFrame) -> bytes:
+    """Serialize *df* to Parquet, stringifying any object column that mixes
+    numeric values with non-numeric strings.
+
+    pyarrow infers one logical type per column and raises ArrowInvalid if an
+    object column holds both — e.g. a WQP analyte's parameter_value column
+    carrying floats *and* the non-detect marker 'ND' (numeric results convert to
+    float in _apply_unit_conversion, qualitative ones stay strings). Casting such
+    a column to str lets the qualitative markers survive the round-trip; every
+    downstream consumer already float()-coerces and skips non-numeric values
+    (see backend.trend_stats.daily_series)."""
+    for col in df.columns:
+        vals = [v for v in df[col] if not _is_null(v)]
+        has_num = any(isinstance(v, (int, float)) and not isinstance(v, bool) for v in vals)
+        has_str = any(isinstance(v, str) for v in vals)
+        if has_num and has_str:
+            df[col] = [None if _is_null(v) else str(v) for v in df[col]]
+    buf = io.BytesIO()
+    df.to_parquet(buf, index=False)
+    return buf.getvalue()
+
+
+def _is_null(v) -> bool:
+    """None or a float NaN. Scalar-only — payload columns are flat scalars."""
+    return v is None or (isinstance(v, float) and v != v)
+
+
 def dicts_to_parquet_bytes(dicts: list[dict]) -> bytes:
     """Serialize a flat list of payload dicts (records or sites) to Parquet.
     object dtype keeps exact types; a uniform column set is fine — the record
     classes tolerate extra null-valued keys on rebuild."""
-    buf = io.BytesIO()
-    pd.DataFrame(dicts, dtype=object).to_parquet(buf, index=False)
-    return buf.getvalue()
+    return _frame_to_parquet_bytes(pd.DataFrame(dicts, dtype=object))
 
 
 def parquet_bytes_to_dicts(data: bytes) -> list[dict]:
@@ -218,9 +243,7 @@ def timeseries_to_parquet_bytes(timeseries: list[list[dict]]) -> bytes:
     for site_idx, site_ts in enumerate(timeseries):
         for obs in site_ts:
             rows.append({**obs, _SITE_IDX: site_idx})
-    buf = io.BytesIO()
-    pd.DataFrame(rows, dtype=object).to_parquet(buf, index=False)
-    return buf.getvalue()
+    return _frame_to_parquet_bytes(pd.DataFrame(rows, dtype=object))
 
 
 def parquet_bytes_to_timeseries(data: bytes) -> list[list[dict]]:


### PR DESCRIPTION
## Problem

Source steps crash in the Dagster Parquet handoff when an analyte's `parameter_value` column mixes numeric and qualitative values:

```
pyarrow.lib.ArrowInvalid: Could not convert 'ND' ... for column parameter_value
pyarrow.lib.ArrowInvalid: Could not convert '< MRL 10 MG/L' ...
pyarrow.lib.ArrowTypeError: Expected bytes, got a 'float' object ...
```

WQP non-detects arrive as `ResultMeasureValue='ND'`; NMED DWB emits below-reporting-limit markers like `'< MRL 0.1 MG/L'`. In `_apply_unit_conversion` numeric results convert to `float` while `float('ND')` raises and the raw string is deliberately kept ("Keeping ... for time series data"). pyarrow infers one logical type per column and can't hold both — crashing whichever way it guessed (double → ArrowInvalid, string → ArrowTypeError).

Observed sources/analytes: `wqp` (arsenic, carbonate), `nmed_dwb` (calcium, chloride). Any analyte with a non-detect / below-MRL result hits it.

## Fix

`backend/persisters/geodataframe.py`: new `_frame_to_parquet_bytes` helper scans each column and, if it mixes numeric values with non-numeric strings, casts the whole column to `str` before writing (nulls preserved). Both `dicts_to_parquet_bytes` (records/sites) and `timeseries_to_parquet_bytes` (observations) route through it. Order-independent — covers both the `double`-inferred and `string`-inferred crash variants.

Qualitative markers are intentional time-series data, so they are kept rather than dropped. Every downstream consumer already `float()`-coerces and skips non-numeric values (`backend.trend_stats.daily_series`), so string storage is safe.

**Note:** `parameter_value` dtype now varies by batch — `float64` when clean, `str` when any qualitative value is present. Any future reader must not assume a fixed dtype.

## Verification

Against real pyarrow: both crash variants (`'ND'`/`'< MRL ...'` with floats, in either value ordering) round-trip with markers intact; all-numeric batches keep `float64`. Local persister suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)